### PR TITLE
Fix RSSI reporting bug

### DIFF
--- a/firmware/vent-controller/src/coap.rs
+++ b/firmware/vent-controller/src/coap.rs
@@ -1,5 +1,6 @@
 use crate::identity::DeviceIdentity;
 use crate::state::VentStateMachine;
+use crate::thread::ThreadManager;
 use log::{info, warn};
 use minicbor::{to_vec, Decoder};
 use vent_protocol::*;
@@ -11,6 +12,7 @@ const FIRMWARE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct AppState {
     pub vent: VentStateMachine,
     pub identity: DeviceIdentity,
+    pub thread: ThreadManager,
     pub start_time: Instant,
     pub power_source: PowerSource,
     pub poll_period_ms: u32,
@@ -133,7 +135,7 @@ pub fn handle_put_config(state: &mut AppState, payload: &[u8]) -> CoapResponse {
 /// Handle GET /device/health
 pub fn handle_get_health(state: &AppState) -> CoapResponse {
     let health = DeviceHealth {
-        rssi: -50, // TODO: read from Thread stack
+        rssi: state.thread.get_rssi(),
         poll_period_ms: state.poll_period_ms,
         power_source: state.power_source,
         free_heap: unsafe { esp_idf_sys::esp_get_free_heap_size() },

--- a/firmware/vent-controller/src/main.rs
+++ b/firmware/vent-controller/src/main.rs
@@ -124,6 +124,7 @@ fn main() {
     let mut app_state = AppState {
         vent: vent_state,
         identity: device_id,
+        thread: thread_mgr,
         start_time: Instant::now(),
         power_source: match power_mode {
             PowerMode::AlwaysOn => PowerSource::Usb,

--- a/firmware/vent-controller/src/thread.rs
+++ b/firmware/vent-controller/src/thread.rs
@@ -140,15 +140,14 @@ impl ThreadManager {
         }
     }
 
-    /// Get the RSSI of the last received packet.
+    /// Get the average RSSI of the link to the parent router.
     pub fn get_rssi(&self) -> i8 {
         unsafe {
             let instance = esp_idf_sys::esp_openthread_get_instance();
-            let mut parent_info: esp_idf_sys::otRouterInfo = std::mem::zeroed();
-            if esp_idf_sys::otThreadGetParentInfo(instance, &mut parent_info)
-                == esp_idf_sys::OT_ERROR_NONE as u32
-            {
-                parent_info.mRloc16 as i8
+            let mut avg_rssi: i8 = -128;
+            let err = esp_idf_sys::otThreadGetParentAverageRssi(instance, &mut avg_rssi);
+            if err == esp_idf_sys::OT_ERROR_NONE as u32 {
+                avg_rssi
             } else {
                 -128
             }


### PR DESCRIPTION
## Summary
- Fix `get_rssi()` in `thread.rs` — was returning `mRloc16` (network address) cast to `i8` instead of actual RSSI
- Now uses `otThreadGetParentAverageRssi()` for real signal strength
- Wire `ThreadManager` into `AppState` so health endpoint returns live RSSI instead of hardcoded `-50`

Fixes #3