### PR TITLE
Add /device/health polling to HA coordinator

### DIFF
--- a/homeassistant/custom_components/vent_control/coordinator.py
+++ b/homeassistant/custom_components/vent_control/coordinator.py
@@ -101,6 +101,21 @@ class VentCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         except Exception:
             pass
 
+        # Get health
+        try:
+            msg = Message(code=Code.GET, uri=f"coap://[{address}]/device/health")
+            resp = await self._coap_context.request(msg).response
+            if resp.code.is_successful():
+                data = cbor2.loads(resp.payload)
+                result["rssi"] = data.get(0, 0)
+                result["poll_period_ms"] = data.get(1, 0)
+                power_sources = {0: "usb", 1: "battery"}
+                result["power_source"] = power_sources.get(data.get(2, 0), "usb")
+                result["free_heap"] = data.get(3, 0)
+                result["battery_mv"] = data.get(4)
+        except Exception:
+            pass
+
         return result
 
     async def async_set_vent_position(self, address: str, angle: int) -> bool:

--- a/homeassistant/custom_components/vent_control/cover.py
+++ b/homeassistant/custom_components/vent_control/cover.py
@@ -109,13 +109,19 @@ class VentCoverEntity(CoordinatorEntity[VentCoordinator], CoverEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         data = self._device_data
-        return {
+        attrs = {
             "eui64": self._eui64,
             "angle": data.get("angle"),
             "room": data.get("room", ""),
             "floor": data.get("floor", ""),
             "firmware_version": data.get("firmware_version", ""),
+            "rssi": data.get("rssi"),
+            "power_source": data.get("power_source", ""),
+            "free_heap": data.get("free_heap"),
         }
+        if data.get("battery_mv") is not None:
+            attrs["battery_mv"] = data["battery_mv"]
+        return attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
## Summary
- `coordinator.py`: poll `/device/health` on each update cycle, parsing RSSI, power source, free heap, and battery_mv from CBOR
- `cover.py`: expose health fields (`rssi`, `power_source`, `free_heap`, `battery_mv`) in `extra_state_attributes`

Fixes #6