### PR TITLE
Fix is_opening/is_closing to detect vent direction

### DIFF
--- a/homeassistant/custom_components/vent_control/cover.py
+++ b/homeassistant/custom_components/vent_control/cover.py
@@ -83,11 +83,21 @@ class VentCoverEntity(CoordinatorEntity[VentCoordinator], CoverEntity):
 
     @property
     def is_opening(self) -> bool:
-        return self._device_data.get("state") == "moving"
+        data = self._device_data
+        if data.get("state") != "moving":
+            return False
+        target = data.get("target_angle")
+        angle = data.get("angle", ANGLE_CLOSED)
+        return target is not None and target > angle
 
     @property
     def is_closing(self) -> bool:
-        return self._device_data.get("state") == "moving"
+        data = self._device_data
+        if data.get("state") != "moving":
+            return False
+        target = data.get("target_angle")
+        angle = data.get("angle", ANGLE_CLOSED)
+        return target is not None and target < angle
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the vent fully."""


### PR DESCRIPTION
## Summary
- Both `is_opening` and `is_closing` returned `state == "moving"`, making HA unable to distinguish direction
- Coordinator now tracks `target_angle` from `async_set_vent_position()` and includes it in poll data
- Cover entity compares current angle vs target: `target > current` = opening, `target < current` = closing
- Target is cleared automatically when movement completes

Fixes #7