### PR TITLE
Update docs to reflect fixes #3-#8

### DIFF
--- a/docs/communication-protocol.md
+++ b/docs/communication-protocol.md
@@ -115,7 +115,7 @@ Returns device health telemetry.
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `rssi` | i8 | Thread RSSI in dBm |
+| `rssi` | i8 | Average RSSI of parent link in dBm (via otThreadGetParentAverageRssi). -128 if unavailable |
 | `poll_period_ms` | u32 | SED poll period (0 if always-on) |
 | `power_source` | str | `"usb"` or `"battery"` |
 | `free_heap` | u32 | Free heap in bytes |


### PR DESCRIPTION
## Summary
10 doc discrepancies fixed across 3 files after the recent bug fix/enhancement PRs:

- **architecture.md**: Add `pwr_mode`/`poll_ms` to NVS persistence table, update component descriptions for `identity.rs` (power mode keys), `thread.rs` (live RSSI), `coap.rs` (AppState struct), `coordinator.py` (health polling + target tracking), `cover.py` (new attributes + direction detection)
- **communication-protocol.md**: Clarify RSSI field is parent average via `otThreadGetParentAverageRssi`, -128 if unavailable
- **rfc.md**: Add NVS power mode keys to device identity section, fix incorrect claim that poll period is set via `/device/config` (it uses NVS keys directly), update HA integration section with health polling and direction detection