### PR TITLE
Add esp-matter SDK component with Window Covering endpoint

### DIFF
--- a/docs/guides/setup-dev-env.md
+++ b/docs/guides/setup-dev-env.md
@@ -34,6 +34,8 @@ cargo build
 
 The first build will download and compile ESP-IDF (takes several minutes).
 
+**Note:** The firmware uses the [ESP-IDF Component Manager](https://components.espressif.com/) to pull `esp_matter` and its transitive dependencies automatically during the first build. No manual submodule setup is required.
+
 ### 5. Run Host Tests
 
 ```bash

--- a/firmware/vent-controller/components/esp_matter_bridge/CMakeLists.txt
+++ b/firmware/vent-controller/components/esp_matter_bridge/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "matter_bridge.cpp"
+    INCLUDE_DIRS "include"
+    REQUIRES esp_matter nvs_flash esp_event
+)

--- a/firmware/vent-controller/components/esp_matter_bridge/idf_component.yml
+++ b/firmware/vent-controller/components/esp_matter_bridge/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  espressif/esp_matter:
+    version: "^1.3"

--- a/firmware/vent-controller/components/esp_matter_bridge/include/matter_bridge.h
+++ b/firmware/vent-controller/components/esp_matter_bridge/include/matter_bridge.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Callback invoked when a Matter controller sets the target position.
+ * @param percent100ths Target position in 0–10000 (100ths of a percent)
+ * @param ctx User context pointer passed to matter_bridge_init()
+ */
+typedef void (*matter_position_cb_t)(uint16_t percent100ths, void *ctx);
+
+/**
+ * Callback invoked when a Matter controller triggers the Identify cluster.
+ * @param duration_s Identify duration in seconds
+ * @param ctx User context pointer passed to matter_bridge_init()
+ */
+typedef void (*matter_identify_cb_t)(uint16_t duration_s, void *ctx);
+
+/**
+ * Initialize the Matter node with a Window Covering endpoint.
+ * Must be called before matter_bridge_start().
+ *
+ * @param position_cb Called when controller changes target position
+ * @param identify_cb Called when controller triggers identify
+ * @param ctx User context forwarded to callbacks
+ * @return 0 on success, non-zero on failure
+ */
+int matter_bridge_init(matter_position_cb_t position_cb,
+                       matter_identify_cb_t identify_cb,
+                       void *ctx);
+
+/**
+ * Start the Matter event loop. This must be called after matter_bridge_init().
+ * Matter will manage the OpenThread stack internally.
+ * @return 0 on success, non-zero on failure
+ */
+int matter_bridge_start(void);
+
+/**
+ * Report the current vent position to the Matter fabric.
+ * @param percent100ths Current position in 0–10000
+ */
+void matter_bridge_update_position(uint16_t percent100ths);
+
+/**
+ * Report operational status (moving / stopped).
+ * @param status 0 = stopped, non-zero = moving
+ */
+void matter_bridge_update_operational_status(uint8_t status);
+
+/**
+ * Check if the device has been commissioned into a Matter fabric.
+ * @return true if commissioned
+ */
+bool matter_bridge_is_commissioned(void);
+
+/**
+ * Get the manual pairing code string (e.g. "34970112332").
+ * @param buf Output buffer
+ * @param len Buffer length
+ * @return 0 on success, non-zero if not yet available
+ */
+int matter_bridge_get_pairing_code(char *buf, size_t len);
+
+/**
+ * Get the QR code payload string (e.g. "MT:...").
+ * @param buf Output buffer
+ * @param len Buffer length
+ * @return 0 on success, non-zero if not yet available
+ */
+int matter_bridge_get_qr_payload(char *buf, size_t len);
+
+/**
+ * Factory-reset Matter state: clear fabrics, restart BLE advertising.
+ */
+void matter_bridge_factory_reset(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/vent-controller/components/esp_matter_bridge/matter_bridge.cpp
+++ b/firmware/vent-controller/components/esp_matter_bridge/matter_bridge.cpp
@@ -1,0 +1,192 @@
+#include "matter_bridge.h"
+
+#include <esp_log.h>
+#include <esp_matter.h>
+#include <esp_matter_endpoint.h>
+#include <app/server/Server.h>
+
+static const char *TAG = "matter_bridge";
+
+using namespace esp_matter;
+using namespace esp_matter::endpoint;
+using namespace chip::app::Clusters;
+
+// --- Stored callbacks and state ---
+
+static matter_position_cb_t s_position_cb = nullptr;
+static matter_identify_cb_t s_identify_cb = nullptr;
+static void *s_user_ctx = nullptr;
+static uint16_t s_endpoint_id = 0;
+static node_t *s_node = nullptr;
+
+// --- Matter attribute update callback ---
+
+static esp_err_t app_attribute_update_cb(
+    attribute::callback_type_t type,
+    uint16_t endpoint_id,
+    uint32_t cluster_id,
+    uint32_t attribute_id,
+    esp_matter_attr_val_t *val,
+    void *priv_data)
+{
+    if (type != attribute::PRE_UPDATE) {
+        return ESP_OK;
+    }
+
+    if (endpoint_id != s_endpoint_id) {
+        return ESP_OK;
+    }
+
+    // WindowCovering cluster: GoToLiftPercentage sets CurrentPositionLiftPercent100ths
+    if (cluster_id == WindowCovering::Id) {
+        if (attribute_id == WindowCovering::Attributes::TargetPositionLiftPercent100ths::Id) {
+            uint16_t pct = val->val.u16;
+            ESP_LOGI(TAG, "Matter: target position set to %u/10000", pct);
+            if (s_position_cb) {
+                s_position_cb(pct, s_user_ctx);
+            }
+        }
+    }
+
+    return ESP_OK;
+}
+
+// --- Matter identification callback ---
+
+static esp_err_t app_identification_cb(
+    identification::callback_type_t type,
+    uint16_t endpoint_id,
+    uint8_t effect_id,
+    uint8_t effect_variant,
+    void *priv_data)
+{
+    if (type == identification::START) {
+        ESP_LOGI(TAG, "Matter: identify START (effect=%u)", effect_id);
+        if (s_identify_cb) {
+            s_identify_cb(10, s_user_ctx);  // default 10s identify
+        }
+    } else if (type == identification::STOP) {
+        ESP_LOGI(TAG, "Matter: identify STOP");
+        if (s_identify_cb) {
+            s_identify_cb(0, s_user_ctx);
+        }
+    }
+    return ESP_OK;
+}
+
+// --- Public C API ---
+
+int matter_bridge_init(matter_position_cb_t position_cb,
+                       matter_identify_cb_t identify_cb,
+                       void *ctx)
+{
+    ESP_LOGI(TAG, "Initializing Matter node...");
+
+    s_position_cb = position_cb;
+    s_identify_cb = identify_cb;
+    s_user_ctx = ctx;
+
+    // Create Matter node
+    node::config_t node_config;
+    s_node = node::create(&node_config, app_attribute_update_cb, app_identification_cb);
+    if (!s_node) {
+        ESP_LOGE(TAG, "Failed to create Matter node");
+        return -1;
+    }
+
+    // Create Window Covering endpoint
+    window_covering_device::config_t wc_config;
+    wc_config.window_covering.type = 0;  // Rollershade
+    wc_config.window_covering.config_status = 0x00;
+    wc_config.window_covering.operational_status = 0;
+    wc_config.window_covering.end_product_type = 0;  // Rollershade
+    wc_config.window_covering.mode = 0;
+
+    endpoint_t *ep = window_covering_device::create(s_node, &wc_config,
+                                                     ENDPOINT_FLAG_NONE, nullptr);
+    if (!ep) {
+        ESP_LOGE(TAG, "Failed to create Window Covering endpoint");
+        return -1;
+    }
+    s_endpoint_id = endpoint::get_id(ep);
+    ESP_LOGI(TAG, "Window Covering endpoint ID: %u", s_endpoint_id);
+
+    // Set Basic Information cluster attributes
+    endpoint_t *root_ep = endpoint::get_first(s_node);
+    if (root_ep) {
+        uint16_t root_id = endpoint::get_id(root_ep);
+        cluster_t *basic_cluster = cluster::get(root_ep, BasicInformation::Id);
+        if (basic_cluster) {
+            // VendorName
+            esp_matter_attr_val_t vendor_name = esp_matter_char_str("SmartVent", 9);
+            attribute::update(root_id, BasicInformation::Id,
+                            BasicInformation::Attributes::VendorName::Id, &vendor_name);
+
+            // ProductName
+            esp_matter_attr_val_t product_name = esp_matter_char_str("Smart HVAC Vent", 15);
+            attribute::update(root_id, BasicInformation::Id,
+                            BasicInformation::Attributes::ProductName::Id, &product_name);
+        }
+    }
+
+    ESP_LOGI(TAG, "Matter node initialized (VID=0xFFF1, PID=0x8001)");
+    return 0;
+}
+
+int matter_bridge_start(void)
+{
+    ESP_LOGI(TAG, "Starting Matter event loop...");
+    esp_err_t err = esp_matter::start(nullptr);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_matter::start() failed: %d", err);
+        return -1;
+    }
+    ESP_LOGI(TAG, "Matter started");
+    return 0;
+}
+
+void matter_bridge_update_position(uint16_t percent100ths)
+{
+    ESP_LOGI(TAG, "Reporting position: %u/10000", percent100ths);
+
+    esp_matter_attr_val_t val = esp_matter_nullable_uint16(percent100ths);
+    attribute::update(s_endpoint_id, WindowCovering::Id,
+                     WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id, &val);
+}
+
+void matter_bridge_update_operational_status(uint8_t status)
+{
+    ESP_LOGI(TAG, "Reporting operational status: %u", status);
+
+    esp_matter_attr_val_t val = esp_matter_uint8(status);
+    attribute::update(s_endpoint_id, WindowCovering::Id,
+                     WindowCovering::Attributes::OperationalStatus::Id, &val);
+}
+
+bool matter_bridge_is_commissioned(void)
+{
+    auto &server = chip::Server::GetInstance();
+    return server.GetFabricTable().FabricCount() > 0;
+}
+
+int matter_bridge_get_pairing_code(char *buf, size_t len)
+{
+    // Will be implemented in PR 5 (BLE commissioning)
+    ESP_LOGW(TAG, "matter_bridge_get_pairing_code: not yet implemented");
+    if (len > 0) buf[0] = '\0';
+    return -1;
+}
+
+int matter_bridge_get_qr_payload(char *buf, size_t len)
+{
+    // Will be implemented in PR 5 (BLE commissioning)
+    ESP_LOGW(TAG, "matter_bridge_get_qr_payload: not yet implemented");
+    if (len > 0) buf[0] = '\0';
+    return -1;
+}
+
+void matter_bridge_factory_reset(void)
+{
+    ESP_LOGW(TAG, "Factory reset requested");
+    chip::Server::GetInstance().ScheduleFactoryReset();
+}

--- a/firmware/vent-controller/partitions.csv
+++ b/firmware/vent-controller/partitions.csv
@@ -1,0 +1,4 @@
+# Name,   Type, SubType, Offset,   Size
+nvs,      data, nvs,     0x9000,  0x6000
+phy_init, data, phy,     0xf000,  0x1000
+factory,  app,  factory, 0x10000, 0x1E0000

--- a/firmware/vent-controller/sdkconfig.defaults
+++ b/firmware/vent-controller/sdkconfig.defaults
@@ -11,8 +11,9 @@ CONFIG_IEEE802154_ENABLED=y
 CONFIG_VFS_SUPPORT_SELECT=y
 CONFIG_ESP_EVENTFD=y
 
-# Stack sizes — OpenThread requires larger stacks than defaults
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=6144
+# Stack sizes — OpenThread + Matter require larger stacks
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+CONFIG_CHIP_TASK_STACK_SIZE=8192
 
 # Power management
 CONFIG_PM_ENABLE=y
@@ -20,8 +21,23 @@ CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
 
 # CoAP — enabled via components/ot_coap_config (OPENTHREAD_CONFIG_COAP_API_ENABLE)
 
-# Partition table — use large app partition (1.5MB) for OpenThread firmware
-CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y
+# Matter
+CONFIG_ESP_MATTER_ENABLE_MATTER_SERVER=y
+CONFIG_ENABLE_CHIP_SHELL=n
+
+# BLE commissioning
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+
+# Crypto — required by Matter (CASE/PASE)
+CONFIG_MBEDTLS_CMAC_C=y
+CONFIG_MBEDTLS_HKDF_C=y
+CONFIG_MBEDTLS_ECJPAKE_C=y
+
+# Custom partition table — 1.9MB app partition for Matter + BLE + Thread
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
 # NVS
 CONFIG_NVS_ENABLED=y


### PR DESCRIPTION
## Summary
- Add `esp_matter_bridge` C++ component with flat C API for Rust FFI
- Create Matter node with Window Covering endpoint (position control, identify)
- Custom 1.9MB partition table for Matter + BLE + Thread binary
- Update sdkconfig.defaults with Matter, BLE (NimBLE), and crypto settings
- Pull `esp_matter ^1.3` via ESP-IDF Component Manager (no git submodules)

Depends on #21.

## Test plan
- [ ] `cargo build --release` succeeds with esp-matter linked
- [ ] Binary fits in 1.9MB partition
- [ ] Existing protocol host tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)