### PR TITLE
Add BLE commissioning support and QR code generation

### DIFF
--- a/docs/guides/flash-firmware.md
+++ b/docs/guides/flash-firmware.md
@@ -74,7 +74,26 @@ join the network within a few seconds:
 OPENTHREAD:[N] Mle-----------: Role detached -> child
 ```
 
-## 4. Verify CoAP
+## 4. Matter Pairing Information
+
+After boot, the serial output will display the Matter pairing information:
+
+```
+Manual pairing code: 34970112332
+QR code payload: MT:Y3.13OTB00KA0648G00
+```
+
+Use the **manual pairing code** when commissioning via CLI tools (e.g. `chip-tool`), or generate a printable QR code:
+
+```bash
+cd tools/qr-generator
+pip install qrcode[pil]
+python generate_qr.py "MT:Y3.13OTB00KA0648G00" --output vent-qr.png
+```
+
+Scan the QR code with the Google Home, Alexa, or Apple Home app to commission the device.
+
+## 5. Verify CoAP
 
 From the hub (or any machine on the Thread network):
 

--- a/tools/qr-generator/generate_qr.py
+++ b/tools/qr-generator/generate_qr.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Generate a printable QR code from a Matter QR payload string.
+
+Usage:
+    python generate_qr.py "MT:Y3.13OTB00KA0648G00"
+    python generate_qr.py "MT:Y3.13OTB00KA0648G00" --output vent-qr.png
+"""
+
+import argparse
+import sys
+
+try:
+    import qrcode
+except ImportError:
+    print("Install qrcode: pip install qrcode[pil]", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a Matter QR code for device commissioning"
+    )
+    parser.add_argument("payload", help="Matter QR payload string (e.g. MT:...)")
+    parser.add_argument(
+        "--output", "-o", default="matter-qr.png", help="Output PNG file path"
+    )
+    parser.add_argument(
+        "--size", type=int, default=10, help="Box size in pixels (default: 10)"
+    )
+    args = parser.parse_args()
+
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=args.size,
+        border=4,
+    )
+    qr.add_data(args.payload)
+    qr.make(fit=True)
+
+    img = qr.make_image(fill_color="black", back_color="white")
+    img.save(args.output)
+    print(f"QR code saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Derive Matter discriminator from device EUI-64 lower 12 bits
- Implement `matter_bridge_get_pairing_code()` and `matter_bridge_get_qr_payload()` using CHIP SDK payload generators
- Add `tools/qr-generator/generate_qr.py` — generates printable PNG QR codes from Matter payload strings
- Update `flash-firmware.md` with Matter pairing info section

Partially addresses #20 (onboarding). Depends on #24.

## Test plan
- [ ] Flash device, observe BLE advertising + pairing info in serial output
- [ ] Commission via `chip-tool pairing ble-thread <node-id> <dataset> <passcode> <discriminator>`
- [ ] Generate QR code with `generate_qr.py`, scan with Google Home/Alexa/Apple Home
- [ ] Verify CoAP backward compat after commissioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)