### PR TITLE
Add Matter validation test procedure and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smart Vent Control System
 
-Per-room HVAC vent control using ESP32-C6 + SG90 servos over Thread, managed by a Raspberry Pi 4B hub running Home Assistant.
+Per-room HVAC vent control using ESP32-C6 + SG90 servos over Thread. Supports **Matter** for Google Home, Alexa, and Apple Home, plus a CoAP protocol for the custom Python hub and Home Assistant integration.
 
 ## Architecture
 
@@ -61,17 +61,30 @@ tests/integration/  End-to-end tests (hub + simulator)
 
 ## Key Features
 
+- **Matter support**: Works with Google Home, Alexa, Apple Home, and HA Matter integration
 - **Per-vent control**: 90° (closed) to 180° (open)
 - **Room/floor grouping**: Batch operations on groups of vents
 - **Permanent device ID**: EUI-64 from ESP32-C6 eFuse
-- **Auto-discovery**: New devices found via OTBR
+- **BLE commissioning**: Scan a QR code to add devices to any ecosystem
+- **Multi-admin**: Control from multiple ecosystems simultaneously
+- **Auto-discovery**: New devices found via OTBR (legacy CoAP) or Matter commissioning
 - **Battery support**: Optional deep sleep (Thread SED mode)
 - **Local only**: No cloud — all traffic stays on Thread mesh
-- **Home Assistant**: Vents appear as cover entities
+- **Home Assistant**: Vents appear as cover entities (via Matter or custom component)
 
 ## Protocol
 
-CoAP over IPv6/Thread with CBOR payloads:
+The firmware runs two protocols simultaneously over Thread:
+
+**Matter** (Window Covering cluster) — Industry standard, used by Google Home/Alexa/Apple Home/HA:
+
+| Cluster | Commands | Purpose |
+|---------|----------|---------|
+| Window Covering | UpOrOpen, DownOrClose, GoToLiftPercentage | Position control |
+| Window Covering | CurrentPositionLiftPercent100ths | Position reporting |
+| Identify | Identify | Servo wiggle for identification |
+
+**CoAP + CBOR** — Custom protocol for the Python hub:
 
 | Resource | Methods | Purpose |
 |----------|---------|---------|

--- a/docs/guides/commissioning.md
+++ b/docs/guides/commissioning.md
@@ -2,9 +2,70 @@
 
 ## Overview
 
-Commissioning adds a new ESP32-C6 vent controller to the Thread network and
-registers it with the hub. Both the OTBR and the device must share the same
-Thread network credentials (network key, channel, PAN ID, network name).
+Commissioning adds a new ESP32-C6 vent controller to the Thread network. The firmware supports two commissioning methods:
+
+1. **Matter commissioning (recommended)** — BLE-based onboarding via Google Home, Alexa, Apple Home, or chip-tool. Thread credentials are provisioned automatically during commissioning.
+2. **Legacy CoAP commissioning** — Hardcoded Thread credentials matching the OTBR dataset. Used with the Python hub CLI.
+
+## Matter Commissioning (Recommended)
+
+### 1. Flash the Firmware
+
+See [flash-firmware.md](flash-firmware.md). After boot, the serial output displays the pairing info:
+
+```
+Manual pairing code: 34970112332
+QR code payload: MT:Y3.13OTB00KA0648G00
+```
+
+### 2. Commission via App or CLI
+
+**Google Home / Alexa / Apple Home:**
+1. Open the ecosystem app
+2. Add a new device → scan the QR code (or enter the manual pairing code)
+3. The app provisions Thread credentials and adds the device to the fabric
+
+**chip-tool (development):**
+```bash
+chip-tool pairing ble-thread <node-id> hex:<dataset> <passcode> <discriminator>
+```
+
+### 3. Verify Operation
+
+After commissioning, the device joins the Thread network automatically:
+```
+OPENTHREAD:[N] Mle-----------: Role detached -> child
+Matter: commissioned into fabric
+```
+
+Test via chip-tool:
+```bash
+# Open vent (0% = fully open)
+chip-tool windowcovering up-or-open 1 1
+# Close vent (100% = fully closed)
+chip-tool windowcovering down-or-close 1 1
+# Set to 50%
+chip-tool windowcovering go-to-lift-percentage 5000 1 1
+# Read position
+chip-tool windowcovering read current-position-lift-percent100ths 1 1
+```
+
+### 4. Multi-Admin (Optional)
+
+Matter supports multi-admin — a single device can be controlled by multiple ecosystems simultaneously. After initial commissioning, open a commissioning window from the first controller to add a second:
+
+```bash
+# From chip-tool (as first admin)
+chip-tool pairing open-commissioning-window 1 1 300 1000 3840
+```
+
+Then commission from the second ecosystem app.
+
+---
+
+## Legacy CoAP Commissioning
+
+For use with the Python hub CLI without Matter. Requires matching Thread credentials between OTBR and firmware.
 
 ## Prerequisites
 

--- a/docs/rfc.md
+++ b/docs/rfc.md
@@ -35,11 +35,21 @@ The system provides per-vent, per-room, and per-floor control of vent positions 
 
 ### 4.1 Communication Flow
 
+The firmware runs a dual-protocol stack over Thread:
+
+**Matter path (Google Home, Alexa, Apple Home, HA Matter):**
+1. Device advertises via BLE for commissioning
+2. Commissioner provisions Thread credentials and adds to Matter fabric
+3. Ecosystem apps control via Matter Window Covering cluster
+
+**CoAP path (custom hub):**
 1. ESP32-C6 joins Thread network as MTD (Minimal Thread Device)
 2. Device registers multicast group and exposes CoAP resources
 3. Hub discovers devices via OTBR REST API (`/node/rloc` endpoint)
 4. Hub communicates with devices over CoAP/UDP/IPv6
 5. Home Assistant polls hub service for state updates
+
+Both protocols share the same application state and servo — commands from either side are reflected in the other.
 
 ### 4.2 Network Topology
 

--- a/tests/integration/test_matter_chip_tool.md
+++ b/tests/integration/test_matter_chip_tool.md
@@ -1,0 +1,124 @@
+# Matter chip-tool Integration Test Procedure
+
+Manual test procedure for validating Matter Window Covering functionality using chip-tool.
+
+## Prerequisites
+
+- ESP32-C6 flashed with Matter-enabled firmware
+- chip-tool installed (from connectedhomeip SDK)
+- OTBR running with Thread network active
+
+## 1. Commission Device
+
+```bash
+# Get Thread dataset from OTBR
+docker exec otbr ot-ctl dataset active -x
+
+# Commission via BLE-Thread (use pairing code from serial output)
+chip-tool pairing ble-thread 1 hex:<dataset> <passcode> <discriminator>
+```
+
+- [ ] Commission succeeds without errors
+- [ ] Serial output shows "Matter: commissioned into fabric"
+- [ ] Device appears as child in `docker exec otbr ot-ctl child table`
+
+## 2. Basic Operations
+
+### Open (UpOrOpen)
+```bash
+chip-tool windowcovering up-or-open 1 1
+```
+- [ ] Servo moves to 180° (fully open)
+- [ ] Serial shows "Matter: target position set to 0/10000"
+- [ ] `CurrentPositionLiftPercent100ths` reads 0
+
+### Close (DownOrClose)
+```bash
+chip-tool windowcovering down-or-close 1 1
+```
+- [ ] Servo moves to 90° (fully closed)
+- [ ] Serial shows "Matter: target position set to 10000/10000"
+- [ ] `CurrentPositionLiftPercent100ths` reads 10000
+
+### Set Percentage (GoToLiftPercentage)
+```bash
+chip-tool windowcovering go-to-lift-percentage 5000 1 1
+```
+- [ ] Servo moves to ~135° (50% open)
+- [ ] Serial shows "Matter: target position set to 5000/10000"
+
+### Read Position
+```bash
+chip-tool windowcovering read current-position-lift-percent100ths 1 1
+```
+- [ ] Returns correct percent100ths value
+
+### Read Operational Status
+```bash
+chip-tool windowcovering read operational-status 1 1
+```
+- [ ] Returns 0 when stopped
+- [ ] Returns non-zero during movement (test by reading while servo is moving)
+
+## 3. Edge Cases
+
+### Boundary Values
+```bash
+chip-tool windowcovering go-to-lift-percentage 0 1 1      # Fully open
+chip-tool windowcovering go-to-lift-percentage 10000 1 1   # Fully closed
+chip-tool windowcovering go-to-lift-percentage 1 1 1       # Near-open
+chip-tool windowcovering go-to-lift-percentage 9999 1 1    # Near-closed
+```
+- [ ] All values map correctly (no servo overshoot)
+
+### Stop Motion
+```bash
+chip-tool windowcovering go-to-lift-percentage 0 1 1   # Start long move
+# Immediately:
+chip-tool windowcovering stop-motion 1 1
+```
+- [ ] Servo stops at intermediate position
+- [ ] Position report reflects actual stop point
+
+## 4. CoAP Coexistence
+
+### CoAP command during Matter control
+```bash
+# Set position via Matter
+chip-tool windowcovering go-to-lift-percentage 5000 1 1
+
+# Read position via CoAP
+aiocoap-client coap://[<device-ipv6>]/vent/position
+```
+- [ ] CoAP returns angle=135, state=partial
+
+### CoAP command, then Matter read
+```bash
+# Set target via CoAP
+aiocoap-client -m PUT coap://[<device-ipv6>]/vent/target --payload <cbor-135>
+
+# Read via Matter
+chip-tool windowcovering read current-position-lift-percent100ths 1 1
+```
+- [ ] Matter reports 5000 (50%) after servo reaches target
+
+## 5. Persistence
+
+### Reboot test
+```bash
+chip-tool windowcovering go-to-lift-percentage 3000 1 1
+# Wait for servo to reach target, then power-cycle device
+chip-tool windowcovering read current-position-lift-percent100ths 1 1
+```
+- [ ] After reboot, position reads ~3000
+
+### Factory reset
+- [ ] After `matter_bridge_factory_reset()`, device re-enters BLE advertising
+- [ ] Can be re-commissioned
+
+## 6. Binary Size Check
+
+```bash
+ls -la firmware/vent-controller/target/riscv32imac-esp-espidf/release/vent-controller
+```
+- [ ] Binary fits within 1.9MB partition (< 1,966,080 bytes)


### PR DESCRIPTION
## Summary
- Rewrite `commissioning.md` with Matter BLE commissioning as primary flow; legacy CoAP section preserved
- Add `tests/integration/test_matter_chip_tool.md`: comprehensive manual test procedure (commission, open/close/set%, CoAP coexistence, persistence, binary size)
- Update `README.md` with Matter features, BLE commissioning, multi-admin, protocol tables
- Update `rfc.md` with dual-protocol architecture description

Closes #17. Depends on #25.

## Test plan
- [ ] All chip-tool tests in test_matter_chip_tool.md pass
- [ ] CoAP simultaneous operation verified
- [ ] Binary fits in 1.9MB partition

🤖 Generated with [Claude Code](https://claude.com/claude-code)