### PR TITLE
Add Google Home setup guide and multi-admin docs

### DIFF
--- a/docs/guides/google-home-setup.md
+++ b/docs/guides/google-home-setup.md
@@ -1,0 +1,75 @@
+# Google Home Setup Guide
+
+Control your smart vents with Google Home voice commands and the Google Home app.
+
+## Prerequisites
+
+- Smart vent flashed with Matter-enabled firmware (v0.2.0+)
+- Google Home app (Android or iOS)
+- Google Nest Hub, Nest Mini, or other Thread-capable Google device
+- The Google device must be on the same network as the Thread border router
+
+## 1. Commission via Google Home App
+
+1. Open the **Google Home** app
+2. Tap **+** → **Set up device** → **New device**
+3. Choose your home
+4. The app scans for nearby Matter devices via BLE
+5. When the vent appears, tap it
+6. Scan the **QR code** from the serial output (or enter the manual pairing code)
+7. Wait for commissioning to complete (~30 seconds)
+8. The vent appears as a "Window covering" device
+
+## 2. Assign to a Room
+
+After commissioning:
+1. Google Home prompts you to assign the device to a room
+2. Select the room where the vent is installed (e.g., "Bedroom", "Living Room")
+3. Optionally rename the device (e.g., "Bedroom Vent")
+
+## 3. Voice Commands
+
+| Command | Action |
+|---------|--------|
+| "Hey Google, open the bedroom vent" | Fully open (180°) |
+| "Hey Google, close the bedroom vent" | Fully close (90°) |
+| "Hey Google, set the bedroom vent to 50%" | Half open (135°) |
+| "Hey Google, what's the bedroom vent position?" | Report current position |
+
+**Note:** Google Home maps "open" to 100% open (0% in Matter terms) and "close" to 0% open (100% in Matter terms).
+
+## 4. Routines
+
+Create routines in the Google Home app to automate vent control:
+
+1. Go to **Automations** → **+** (Add)
+2. Add a **Starter** (e.g., time of day, sunrise/sunset)
+3. Add an **Action** → **Adjust home devices** → select the vent
+4. Set the desired position
+
+Example routines:
+- **Morning**: Open bedroom vent at 7:00 AM
+- **Night**: Close guest room vent at 10:00 PM
+- **Away**: Close all vents when everyone leaves
+
+## 5. Multi-Admin with Home Assistant
+
+The vent can be controlled by both Google Home and Home Assistant simultaneously:
+
+1. First commission into Google Home (steps above)
+2. Open a commissioning window from Google Home:
+   - Go to device settings → **Linked Matter apps & services** → **Link new app**
+3. Commission into Home Assistant's Matter integration
+4. Both ecosystems now control the same device — state stays in sync
+
+See [multi-admin.md](multi-admin.md) for detailed instructions.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Device not found during scan | Ensure the vent is powered on and BLE advertising (check serial output). Move phone closer to device. |
+| "Setup failed" error | Power-cycle the vent and try again. Check that your Google Home device supports Thread. |
+| Voice commands don't work | Verify the device is assigned to a room. Try "Hey Google, sync my devices". |
+| Position doesn't update | The Google Home app may cache state. Pull down to refresh. |
+| "Device unavailable" | Check that the vent is powered on and on the Thread network (serial output shows "child" role). |

--- a/docs/guides/multi-admin.md
+++ b/docs/guides/multi-admin.md
@@ -1,0 +1,61 @@
+# Multi-Admin Setup
+
+Matter supports multi-admin — a single vent device can be controlled by multiple ecosystems simultaneously (e.g., Google Home + Home Assistant, or Alexa + Apple Home).
+
+## How It Works
+
+Each ecosystem is a separate **fabric**. When a device is commissioned into a fabric, it receives that fabric's credentials and can communicate with controllers on that fabric. A Matter device can belong to up to 5 fabrics simultaneously.
+
+State changes from any fabric are reflected to all others. If Google Home opens a vent, Home Assistant sees it as open.
+
+## Adding a Second Ecosystem
+
+### Step 1: Commission into the first ecosystem
+
+Follow the setup guide for your primary ecosystem:
+- [Google Home](google-home-setup.md)
+- [Alexa](alexa-setup.md)
+- [Home Assistant Matter](home-assistant-matter.md)
+
+### Step 2: Open a commissioning window
+
+From the first ecosystem, open a commissioning window so the second ecosystem can join:
+
+**From Google Home:**
+1. Open device settings
+2. **Linked Matter apps & services** → **Link new app**
+
+**From Alexa:**
+1. Open device settings in the Alexa app
+2. **Matter** → **Enable pairing mode**
+
+**From Home Assistant:**
+1. Go to **Settings** → **Devices & Services** → **Matter**
+2. Select the device → **Open commissioning window**
+
+**From chip-tool:**
+```bash
+chip-tool pairing open-commissioning-window <node-id> 1 300 1000 3840
+```
+(Opens window for 300 seconds with discriminator 3840)
+
+### Step 3: Commission from the second ecosystem
+
+In the second ecosystem's app, add a new Matter device. It will find the vent via BLE (the commissioning window enables BLE advertising temporarily).
+
+## Supported Combinations
+
+| Primary | Secondary | Notes |
+|---------|-----------|-------|
+| Google Home | Home Assistant | Recommended for HA dashboard + voice control |
+| Google Home | Alexa | Both voice ecosystems |
+| Alexa | Home Assistant | Recommended for HA dashboard + voice control |
+| Apple Home | Home Assistant | Requires Apple TV or HomePod as Thread border router |
+| Home Assistant | Google Home | Commission HA first, then open window for Google |
+
+## Limitations
+
+- Maximum 5 fabrics per device
+- Each ecosystem manages Thread credentials independently
+- Factory reset clears all fabrics — device must be re-commissioned to each
+- Some ecosystems may show slightly different device names or categories

--- a/tests/integration/test_google_home.md
+++ b/tests/integration/test_google_home.md
@@ -1,0 +1,48 @@
+# Google Home Integration Test Checklist
+
+Manual test procedure for validating Google Home integration.
+
+## Prerequisites
+
+- Smart vent with Matter firmware flashed
+- Google Home app on phone
+- Thread-capable Google device (Nest Hub, Nest Mini 2nd gen+)
+
+## Commission
+
+- [ ] Device appears in Google Home app BLE scan
+- [ ] QR code scan succeeds
+- [ ] Manual pairing code entry works as fallback
+- [ ] Commissioning completes within 60 seconds
+- [ ] Device appears as "Window covering" in Google Home
+
+## Voice Commands
+
+- [ ] "Hey Google, open the [room] vent" → opens to 180°
+- [ ] "Hey Google, close the [room] vent" → closes to 90°
+- [ ] "Hey Google, set the [room] vent to 50%" → moves to 135°
+- [ ] "Hey Google, what's the [room] vent position?" → reports correct %
+
+## App Control
+
+- [ ] Slider in Google Home app works
+- [ ] Position updates reflect in app within 5 seconds
+- [ ] Open/Close buttons work
+
+## Routines
+
+- [ ] Create time-based routine (open at specific time)
+- [ ] Routine fires correctly
+- [ ] Vent moves to expected position
+
+## State Sync with Home Assistant
+
+- [ ] Open vent via Google Home → HA shows open
+- [ ] Close vent via HA → Google Home shows closed
+- [ ] Set position via Google Home → HA cover slider updates
+
+## Edge Cases
+
+- [ ] Power-cycle vent → Google Home reconnects within 30s
+- [ ] Remove device from Google Home → can be re-added
+- [ ] Factory reset vent → Google Home shows unavailable, can re-commission


### PR DESCRIPTION
## Summary
- `docs/guides/google-home-setup.md`: Complete setup guide (commissioning, voice commands, routines, troubleshooting)
- `docs/guides/multi-admin.md`: Multi-admin guide for controlling vent from multiple ecosystems
- `tests/integration/test_google_home.md`: Manual test checklist

Closes #18. Depends on #26.

## Test plan
- [ ] Commission via Google Home app
- [ ] Voice commands work (open, close, set %)
- [ ] Routines fire correctly
- [ ] Multi-admin with HA works (state sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)