### PR TITLE
Grant workflow contents:write for release publishing

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -20,6 +20,9 @@ env:
   CHIP: esp32c6
   RUST_TARGET: riscv32imac-esp-espidf
 
+permissions:
+  contents: write   # softprops/action-gh-release needs this to create/update releases
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The tag-triggered firmware.yml run fails at the 'Publish release' step with HTTP 403 'Resource not accessible by integration' because the default GITHUB_TOKEN doesn't include contents:write. Adds a top-level permissions block so softprops/action-gh-release@v2 can create the GitHub Release.