### PR TITLE
Add smart-vent-provision CLI: flash + labels + kit-card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,9 @@ Thumbs.db
 *.db
 *.sqlite
 
+# Provider tools
+tools/provision/kits/
+.pytest_cache/
+
 # Home Assistant
 homeassistant/custom_components/vent_control/__pycache__/

--- a/tools/provision/README.md
+++ b/tools/provision/README.md
@@ -1,0 +1,95 @@
+# smart-vent-provision
+
+Provider-side CLI for prepping smart-vent kits.
+
+It pulls a tagged firmware release from this repo, flashes the boards
+one at a time (interactively), captures each board's QR + EUI + manual
+pairing code into a per-kit `inventory.json`, then generates printable
+PDFs (sticker sheet + client quick-start card).
+
+## Install
+
+The CLI is published as a Python wheel; until then, install from this
+repo:
+
+```bash
+cd tools/provision
+pip install --user -e .
+
+# Optional dev deps for running the tests:
+pip install --user -e ".[dev]"
+```
+
+External dependency: **espflash** must be on `PATH`.
+
+```bash
+cargo install espflash --version '^3'
+```
+
+## Usage
+
+```bash
+# 1. Flash a batch of vents. Walks through one board at a time.
+smart-vent-provision flash --count 6 \
+  --rooms 'living_room,living_room,study,study,bedroom_1,basement'
+# Writes ./kits/kit-2026-06-20-abc123/inventory.json
+
+# 2. Print sticker sheet (Avery 5160).
+smart-vent-provision labels --kit kit-2026-06-20-abc123 --out labels.pdf
+
+# 3. Print the client quick-start card.
+smart-vent-provision kit-card --kit kit-2026-06-20-abc123 \
+  --ap-password 'changeMe' --support-contact 'help@smart-vent.example'
+```
+
+## Per-vent flow
+
+For each board the CLI prompts:
+
+1. Hold BOOT, replug USB, release BOOT (download mode).
+2. CLI runs `espflash flash --partition-table ... --bootloader ... <app>`.
+3. Power-cycle the board (unplug + replug, no BOOT).
+4. CLI tails `/dev/ttyACM0` for 45s waiting on the boot banner; pulls
+   EUI-64, QR payload, and manual pairing code from the log.
+5. Appends to the kit `inventory.json` with the room hint passed via
+   `--rooms`.
+
+## Inventory schema
+
+```json
+{
+  "kit_id": "kit-2026-06-20-abc123",
+  "firmware_version": "firmware-v0.1.0",
+  "hub_image_version": "",
+  "vents": [
+    {
+      "eui64": "58:e6:c5:01:0a:dc",
+      "qr": "MT:Y3.13OTB00KA0648G00",
+      "manual_code": "34970112332",
+      "label_hint": "living_room"
+    }
+  ]
+}
+```
+
+Hand-editable: fix typos, add hints, reorder. The PDF generators read
+this verbatim.
+
+## Limitations (v1)
+
+- One board at a time. No parallel-flash jig yet (BOOT-hold is still
+  manual per board).
+- `image` subcommand (write SD card) deferred — depends on the Pi
+  hub image, which is the next workstream.
+- Per-vent unique Matter passcodes deferred to v2 (factory NVS
+  partitions + `mfg_tool`). v1 uses the SDK default passcode, like the
+  Pi-side runbook.
+
+## Tests
+
+```bash
+pytest tools/provision/tests -q
+```
+
+No hardware needed — release fetch is mocked, label/QR rendering is
+deterministic.

--- a/tools/provision/README.md
+++ b/tools/provision/README.md
@@ -2,15 +2,30 @@
 
 Provider-side CLI for prepping smart-vent kits.
 
-It pulls a tagged firmware release from this repo, flashes the boards
-one at a time (interactively), captures each board's QR + EUI + manual
-pairing code into a per-kit `inventory.json`, then generates printable
-PDFs (sticker sheet + client quick-start card).
+## Phases — separate by design
+
+This tool is responsible for the **provider** workflow: writing firmware
+to boards and gathering the artifacts needed to print stickers for each
+vent. It does **not** commission anything. Commissioning (pairing a vent
+to a Matter fabric and assigning it to a room) is the **client's** job,
+done from the smart-vent mobile app at install time.
+
+| Phase | Owned by | Tool | Effect |
+|---|---|---|---|
+| Flash | Provider | `smart-vent-provision flash` | Writes firmware to the ESP32-C6 via `espflash`. Nothing else. |
+| Capture | Provider | `smart-vent-provision capture` | Reads the post-boot serial log, records each board's EUI-64 / Matter QR / pairing code into a per-kit `inventory.json`. |
+| Label | Provider | `smart-vent-provision labels` | Renders an Avery 5160 sticker sheet from the inventory. Sticker goes on the physical vent. |
+| Quick-start | Provider | `smart-vent-provision kit-card` | Renders the one-page card that ships in the box. |
+| **Commission** | **Client** | **smart-vent mobile app** | **Scans the sticker QR, pairs the vent into the client's HA fabric, picks the room/floor.** |
+
+The mobile app is a separate project (Flutter, single codebase for
+Android + iOS). It talks to the client's hub via `matter-server`'s
+WebSocket API and HA's REST API. It is not part of this CLI.
 
 ## Install
 
-The CLI is published as a Python wheel; until then, install from this
-repo:
+The CLI is published as a Python wheel via the repo's release pipeline.
+Until that wheel lands, install from this repo:
 
 ```bash
 cd tools/provision
@@ -28,37 +43,59 @@ cargo install espflash --version '^3'
 
 ## Usage
 
+### Flash a board (just the firmware bits)
+
 ```bash
-# 1. Flash a batch of vents. Walks through one board at a time.
-smart-vent-provision flash --count 6 \
-  --rooms 'living_room,living_room,study,study,bedroom_1,basement'
-# Writes ./kits/kit-2026-06-20-abc123/inventory.json
+# Single board
+smart-vent-provision flash
 
-# 2. Print sticker sheet (Avery 5160).
-smart-vent-provision labels --kit kit-2026-06-20-abc123 --out labels.pdf
-
-# 3. Print the client quick-start card.
-smart-vent-provision kit-card --kit kit-2026-06-20-abc123 \
-  --ap-password 'changeMe' --support-contact 'help@smart-vent.example'
+# Several in a row
+smart-vent-provision flash --count 6
 ```
 
-## Per-vent flow
+The CLI prompts you to BOOT-hold + replug, then runs espflash. Repeat
+for as many boards as `--count`. No inventory is written.
 
-For each board the CLI prompts:
+### Capture a board's identity for the sticker
 
-1. Hold BOOT, replug USB, release BOOT (download mode).
-2. CLI runs `espflash flash --partition-table ... --bootloader ... <app>`.
-3. Power-cycle the board (unplug + replug, no BOOT).
-4. CLI tails `/dev/ttyACM0` for 45s waiting on the boot banner; pulls
-   EUI-64, QR payload, and manual pairing code from the log.
-5. Appends to the kit `inventory.json` with the room hint passed via
-   `--rooms`.
+After flashing, power-cycle the board (NO BOOT hold) so it emits a
+fresh boot banner, then:
+
+```bash
+smart-vent-provision capture --kit-id kit-acme-2026-06-001
+# optional cosmetic hint (purely what gets printed on the sticker)
+smart-vent-provision capture --kit-id kit-acme-2026-06-001 --label-hint 'study'
+```
+
+This reads `/dev/ttyACM0` for up to 45s, pulls the EUI-64, Matter QR
+payload, and manual pairing code from the boot log, and appends to
+`./kits/<kit-id>/inventory.json`.
+
+### Flash + capture in one walk (convenience)
+
+```bash
+smart-vent-provision batch --count 6 \
+  --kit-id kit-acme-2026-06-001 \
+  --label-hints 'living room,living room,study,study,bedroom 1,basement'
+```
+
+Walks: BOOT-hold prompt → flash → power-cycle prompt → capture, for
+each of N boards. The label-hints are purely cosmetic printed text;
+they do **not** assign vents to rooms.
+
+### Print stickers + client card
+
+```bash
+smart-vent-provision labels   --kit kit-acme-2026-06-001  # -> labels.pdf
+smart-vent-provision kit-card --kit kit-acme-2026-06-001 \
+  --ap-password 'changeMe' --support-contact 'help@smart-vent.example'
+```
 
 ## Inventory schema
 
 ```json
 {
-  "kit_id": "kit-2026-06-20-abc123",
+  "kit_id": "kit-acme-2026-06-001",
   "firmware_version": "firmware-v0.1.0",
   "hub_image_version": "",
   "vents": [
@@ -66,24 +103,24 @@ For each board the CLI prompts:
       "eui64": "58:e6:c5:01:0a:dc",
       "qr": "MT:Y3.13OTB00KA0648G00",
       "manual_code": "34970112332",
-      "label_hint": "living_room"
+      "label_hint": "study"
     }
   ]
 }
 ```
 
-Hand-editable: fix typos, add hints, reorder. The PDF generators read
-this verbatim.
+Hand-editable. Fix typos, add cosmetic hints, reorder before printing.
+`label_hint` is **just sticker text** — the client app decides the
+actual room during commissioning.
 
 ## Limitations (v1)
 
-- One board at a time. No parallel-flash jig yet (BOOT-hold is still
-  manual per board).
-- `image` subcommand (write SD card) deferred — depends on the Pi
-  hub image, which is the next workstream.
-- Per-vent unique Matter passcodes deferred to v2 (factory NVS
-  partitions + `mfg_tool`). v1 uses the SDK default passcode, like the
-  Pi-side runbook.
+- One board at a time. No parallel flash jig (BOOT-hold is still
+  manual). Operator target: <30 s/board after the first.
+- `image` subcommand (write SD card) deferred — depends on the Pi hub
+  SD image, which is the next workstream.
+- Per-vent unique Matter passcodes deferred to v2 (per-device factory
+  NVS partitions via `mfg_tool`). v1 uses the SDK default passcode.
 
 ## Tests
 

--- a/tools/provision/pyproject.toml
+++ b/tools/provision/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smart-vent-provision"
+version = "0.1.0"
+description = "Provider-side CLI for prepping smart-vent kits: bulk flash, label, image, kit-card."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Mohsen Zainalpour", email = "zainalpour@yahoo.com" }]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
+  "Intended Audience :: System Administrators",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Topic :: System :: Hardware",
+]
+
+dependencies = [
+  "click>=8.1",
+  "requests>=2.31",
+  "pyserial>=3.5",
+  "qrcode[pil]>=7.4",
+  "reportlab>=4.0",
+  "platformdirs>=4.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-mock>=3.12",
+  "responses>=0.25",
+]
+
+[project.scripts]
+smart-vent-provision = "smart_vent_provision.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/EtaCassiopeia/smart-vent"
+Issues = "https://github.com/EtaCassiopeia/smart-vent/issues"
+
+[tool.setuptools.packages.find]
+include = ["smart_vent_provision*"]
+exclude = ["tests*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/provision/smart_vent_provision/__init__.py
+++ b/tools/provision/smart_vent_provision/__init__.py
@@ -1,0 +1,3 @@
+"""Provider-side CLI for prepping smart-vent kits."""
+
+__version__ = "0.1.0"

--- a/tools/provision/smart_vent_provision/cli.py
+++ b/tools/provision/smart_vent_provision/cli.py
@@ -1,6 +1,21 @@
 """smart-vent-provision: provider-side CLI for prepping kits.
 
-Run `smart-vent-provision --help` for the command list.
+Phases (separate by design — flashing and commissioning are not the
+same thing):
+
+  flash    — write firmware to N boards. Nothing else.
+  capture  — read post-boot serial from one board; record its EUI-64,
+             Matter QR payload, and manual pairing code into the kit
+             inventory so we can print a sticker for it. Does NOT
+             commission the device (that's the client's mobile app
+             pairing the QR sticker into their HA fabric, including
+             room/floor assignment).
+  batch    — operator-convenience: walk N boards through flash + capture
+             back to back.
+  labels   — render an Avery 5160 sheet of stickers from the inventory.
+  kit-card — render the one-page client quick-start PDF.
+
+Run `smart-vent-provision <command> --help` for details.
 """
 
 from __future__ import annotations
@@ -20,53 +35,150 @@ DEFAULT_KIT_ROOT = Path.cwd() / "kits"
 @click.group()
 @click.version_option(__version__, prog_name="smart-vent-provision")
 def main() -> None:
-    """Prep smart-vent kits: bulk flash, label, kit-card."""
+    """Prep smart-vent kits: flash, capture, label, kit-card."""
 
 
 # ----------------------------------------------------------------- flash
 @main.command()
-@click.option("--count", "-n", type=int, required=True, help="Number of vents in this batch.")
 @click.option(
-    "--kit-id",
-    type=str,
-    default=None,
-    help="Kit identifier. Defaults to kit-<yyyymmdd>-<short-uid>.",
+    "--count", "-n", type=int, default=1, show_default=True,
+    help="Number of boards to flash one after another.",
 )
 @click.option(
-    "--kit-root",
-    type=click.Path(file_okay=False, path_type=Path),
-    default=DEFAULT_KIT_ROOT,
-    help="Where kit inventories are stored (default: ./kits).",
-)
-@click.option(
-    "--firmware-tag",
-    type=str,
-    default=None,
+    "--firmware-tag", type=str, default=None,
     help="Pin to a specific release tag (default: latest firmware-v*).",
 )
 @click.option(
-    "--port",
-    type=str,
-    default=None,
+    "--port", type=str, default=None,
+    help="Force a specific /dev/tty path; otherwise auto-detect the single XIAO.",
+)
+def flash(count: int, firmware_tag: str | None, port: str | None) -> None:
+    """Write firmware to N boards via espflash. Does not touch any inventory.
+
+    Walk-through per board: BOOT-hold prompt -> espflash -> done.
+    Commissioning (pairing to a Matter fabric, assigning to a room) is
+    a separate step that the client does from their mobile app.
+    """
+    if count <= 0:
+        raise click.BadParameter("count must be >= 1")
+
+    bundle = release.fetch(firmware_tag)
+    click.echo(f"Using firmware {bundle.version} (commit {bundle.commit[:7]}, chip {bundle.chip}).")
+
+    for i in range(count):
+        click.echo("")
+        click.echo(click.style(f"=== board {i + 1} of {count} ===", bold=True))
+        board_port = _prompt_and_resolve_port(port)
+        click.echo("Flashing... (~10s)")
+        flasher.flash(bundle, port=board_port)
+        click.echo(click.style("  flashed.", fg="green"))
+
+
+# --------------------------------------------------------------- capture
+@main.command()
+@click.option(
+    "--kit-id", type=str, default=None,
+    help="Kit identifier. Defaults to kit-<yyyymmdd>-<short-uid> when starting a new kit.",
+)
+@click.option(
+    "--kit-root", type=click.Path(file_okay=False, path_type=Path), default=DEFAULT_KIT_ROOT,
+    help="Where kit inventories are stored (default: ./kits).",
+)
+@click.option(
+    "--firmware-version", type=str, default=None,
+    help="Stamp this firmware version into a NEW inventory (informational).",
+)
+@click.option(
+    "--port", type=str, default=None,
     help="Force a specific /dev/tty path; otherwise auto-detect the single XIAO.",
 )
 @click.option(
-    "--rooms",
-    type=str,
-    default=None,
-    help="Comma-separated room hints to pre-fill (e.g. 'living_room,study,bedroom_1'). "
-    "Applied in order; extras are ignored, shortages get blank.",
+    "--label-hint", type=str, default="",
+    help="Optional printed-sticker text for this vent (e.g. 'living room'). "
+    "Purely cosmetic — does NOT assign the vent to a room. Room assignment "
+    "is the client's mobile-app commissioning step.",
 )
-def flash(
+def capture(
+    kit_id: str | None,
+    kit_root: Path,
+    firmware_version: str | None,
+    port: str | None,
+    label_hint: str,
+) -> None:
+    """Read one board's boot serial; append EUI/QR/pairing-code to the kit inventory.
+
+    Assumes the board is already flashed and currently powered on. Power-
+    cycle the board (no BOOT hold) first so the firmware emits a fresh
+    boot banner with the values we need.
+    """
+    board_port = _prompt_and_resolve_port(port, instruction=
+        "Power-cycle the board (unplug + replug, NO BOOT hold) so it emits a fresh boot banner."
+    )
+
+    click.echo(f"Reading {board_port} for QR + EUI + pairing code...")
+    try:
+        boot = serial_capture.capture(board_port, timeout_s=45.0)
+    except serial_capture.CaptureTimeout as e:
+        raise click.ClickException(str(e)) from None
+
+    kit_id = kit_id or _default_kit_id()
+    inventory_path = kit_root / kit_id / "inventory.json"
+    inventory = _load_or_create(inventory_path, kit_id, firmware_version or "")
+
+    vent = Vent(eui64=boot.eui64, qr=boot.qr, manual_code=boot.manual_code, label_hint=label_hint)
+    try:
+        inventory.add_vent(vent)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from None
+
+    inventory.save(inventory_path)
+    click.echo(click.style(
+        f"  appended: eui …{vent.eui_short} | code {vent.manual_code}"
+        + (f" | hint '{label_hint}'" if label_hint else ""),
+        fg="green",
+    ))
+    click.echo(f"  inventory: {inventory_path} ({len(inventory.vents)} vent(s))")
+
+
+# ----------------------------------------------------------------- batch
+@main.command()
+@click.option("--count", "-n", type=int, required=True, help="Number of boards in this batch.")
+@click.option(
+    "--kit-id", type=str, default=None,
+    help="Kit identifier. Defaults to kit-<yyyymmdd>-<short-uid>.",
+)
+@click.option(
+    "--kit-root", type=click.Path(file_okay=False, path_type=Path), default=DEFAULT_KIT_ROOT,
+)
+@click.option(
+    "--firmware-tag", type=str, default=None,
+    help="Pin to a specific release tag (default: latest firmware-v*).",
+)
+@click.option(
+    "--port", type=str, default=None,
+    help="Force a specific /dev/tty path; otherwise auto-detect the single XIAO.",
+)
+@click.option(
+    "--label-hints", type=str, default=None,
+    help="Comma-separated cosmetic hints to print on each sticker (e.g. "
+    "'living room,study,bedroom 1'). Applied in capture order; extras "
+    "are ignored, shortages get blank.",
+)
+def batch(
     count: int,
     kit_id: str | None,
     kit_root: Path,
     firmware_tag: str | None,
     port: str | None,
-    rooms: str | None,
+    label_hints: str | None,
 ) -> None:
-    """Flash N vents one at a time, capturing QR + EUI into the kit inventory."""
+    """Convenience: walk N boards through flash + capture back-to-back.
 
+    Equivalent to looping `flash` then `capture` per board, but with one
+    cached firmware fetch and a single inventory file at the end.
+    Commissioning (pairing + room assignment) is still entirely client-
+    side via the mobile app.
+    """
     if count <= 0:
         raise click.BadParameter("count must be >= 1")
 
@@ -76,37 +188,31 @@ def flash(
     kit_id = kit_id or _default_kit_id()
     inventory_path = kit_root / kit_id / "inventory.json"
     inventory = _load_or_create(inventory_path, kit_id, bundle.version)
-
-    room_hints = _split_rooms(rooms)
+    hints = _split_csv(label_hints)
 
     for i in range(count):
         seq = len(inventory.vents) + 1
         click.echo("")
-        click.echo(click.style(f"=== vent {seq} of {len(inventory.vents) + count} ===", bold=True))
-        if port:
-            _ = devices.find_existing_port(port)
-            board_port = port
-        else:
-            click.echo("Plug the XIAO directly into a USB port (not a hub).")
-            click.echo("Hold BOOT, replug, release BOOT — then press <enter>.")
-            click.pause(info="(press enter once it's in download mode)")
-            board = devices.find_single_board()
-            board_port = board.port
-            click.echo(f"  Found {board}")
+        click.echo(click.style(f"=== board {seq} (batch {i + 1} of {count}) ===", bold=True))
+        board_port = _prompt_and_resolve_port(port,
+            "Plug the XIAO directly into a USB port (not a hub).\n"
+            "Hold BOOT, replug, release BOOT — then press <enter>.",
+        )
 
-        click.echo("Flashing... (~10s)")
+        click.echo("Flashing...")
         flasher.flash(bundle, port=board_port)
 
-        click.echo("Power-cycle the board (unplug + replug, NO BOOT hold) to boot the new firmware.")
-        click.pause(info="(press enter once the board is back, then wait for the boot banner)")
+        click.pause(info=
+            "Now power-cycle the board (unplug + replug, NO BOOT hold), then press enter."
+        )
 
-        click.echo("Reading serial for QR + EUI...")
+        click.echo("Reading serial...")
         try:
             boot = serial_capture.capture(board_port, timeout_s=45.0)
         except serial_capture.CaptureTimeout as e:
             raise click.ClickException(str(e)) from None
 
-        hint = room_hints[i] if i < len(room_hints) else ""
+        hint = hints[i] if i < len(hints) else ""
         vent = Vent(eui64=boot.eui64, qr=boot.qr, manual_code=boot.manual_code, label_hint=hint)
         try:
             inventory.add_vent(vent)
@@ -115,7 +221,8 @@ def flash(
 
         inventory.save(inventory_path)
         click.echo(click.style(
-            f"  ok: eui …{vent.eui_short} | code {vent.manual_code} | {hint or '(no room hint)'}",
+            f"  ok: eui …{vent.eui_short} | code {vent.manual_code}"
+            + (f" | hint '{hint}'" if hint else ""),
             fg="green",
         ))
 
@@ -210,10 +317,28 @@ def _default_kit_id() -> str:
     return f"kit-{today}-{uuid.uuid4().hex[:6]}"
 
 
-def _split_rooms(spec: str | None) -> list[str]:
+def _split_csv(spec: str | None) -> list[str]:
     if not spec:
         return []
     return [s.strip() for s in spec.split(",") if s.strip()]
+
+
+def _prompt_and_resolve_port(
+    explicit_port: str | None,
+    instruction: str = (
+        "Plug the XIAO directly into a USB port (not a hub).\n"
+        "Hold BOOT, replug, release BOOT — then press <enter>."
+    ),
+) -> str:
+    """Either trust an explicit port path or walk the operator through detection."""
+    if explicit_port:
+        devices.find_existing_port(explicit_port)
+        return explicit_port
+    click.echo(instruction)
+    click.pause(info="(press enter once the board is ready)")
+    board = devices.find_single_board()
+    click.echo(f"  Found {board}")
+    return board.port
 
 
 def _load_or_create(

--- a/tools/provision/smart_vent_provision/cli.py
+++ b/tools/provision/smart_vent_provision/cli.py
@@ -1,0 +1,238 @@
+"""smart-vent-provision: provider-side CLI for prepping kits.
+
+Run `smart-vent-provision --help` for the command list.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sys
+from pathlib import Path
+
+import click
+
+from . import __version__, devices, flasher, kit_card, labels, release, serial_capture
+from .inventory import Inventory, Vent
+
+DEFAULT_KIT_ROOT = Path.cwd() / "kits"
+
+
+@click.group()
+@click.version_option(__version__, prog_name="smart-vent-provision")
+def main() -> None:
+    """Prep smart-vent kits: bulk flash, label, kit-card."""
+
+
+# ----------------------------------------------------------------- flash
+@main.command()
+@click.option("--count", "-n", type=int, required=True, help="Number of vents in this batch.")
+@click.option(
+    "--kit-id",
+    type=str,
+    default=None,
+    help="Kit identifier. Defaults to kit-<yyyymmdd>-<short-uid>.",
+)
+@click.option(
+    "--kit-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=DEFAULT_KIT_ROOT,
+    help="Where kit inventories are stored (default: ./kits).",
+)
+@click.option(
+    "--firmware-tag",
+    type=str,
+    default=None,
+    help="Pin to a specific release tag (default: latest firmware-v*).",
+)
+@click.option(
+    "--port",
+    type=str,
+    default=None,
+    help="Force a specific /dev/tty path; otherwise auto-detect the single XIAO.",
+)
+@click.option(
+    "--rooms",
+    type=str,
+    default=None,
+    help="Comma-separated room hints to pre-fill (e.g. 'living_room,study,bedroom_1'). "
+    "Applied in order; extras are ignored, shortages get blank.",
+)
+def flash(
+    count: int,
+    kit_id: str | None,
+    kit_root: Path,
+    firmware_tag: str | None,
+    port: str | None,
+    rooms: str | None,
+) -> None:
+    """Flash N vents one at a time, capturing QR + EUI into the kit inventory."""
+
+    if count <= 0:
+        raise click.BadParameter("count must be >= 1")
+
+    bundle = release.fetch(firmware_tag)
+    click.echo(f"Using firmware {bundle.version} (commit {bundle.commit[:7]}, chip {bundle.chip}).")
+
+    kit_id = kit_id or _default_kit_id()
+    inventory_path = kit_root / kit_id / "inventory.json"
+    inventory = _load_or_create(inventory_path, kit_id, bundle.version)
+
+    room_hints = _split_rooms(rooms)
+
+    for i in range(count):
+        seq = len(inventory.vents) + 1
+        click.echo("")
+        click.echo(click.style(f"=== vent {seq} of {len(inventory.vents) + count} ===", bold=True))
+        if port:
+            _ = devices.find_existing_port(port)
+            board_port = port
+        else:
+            click.echo("Plug the XIAO directly into a USB port (not a hub).")
+            click.echo("Hold BOOT, replug, release BOOT — then press <enter>.")
+            click.pause(info="(press enter once it's in download mode)")
+            board = devices.find_single_board()
+            board_port = board.port
+            click.echo(f"  Found {board}")
+
+        click.echo("Flashing... (~10s)")
+        flasher.flash(bundle, port=board_port)
+
+        click.echo("Power-cycle the board (unplug + replug, NO BOOT hold) to boot the new firmware.")
+        click.pause(info="(press enter once the board is back, then wait for the boot banner)")
+
+        click.echo("Reading serial for QR + EUI...")
+        try:
+            boot = serial_capture.capture(board_port, timeout_s=45.0)
+        except serial_capture.CaptureTimeout as e:
+            raise click.ClickException(str(e)) from None
+
+        hint = room_hints[i] if i < len(room_hints) else ""
+        vent = Vent(eui64=boot.eui64, qr=boot.qr, manual_code=boot.manual_code, label_hint=hint)
+        try:
+            inventory.add_vent(vent)
+        except ValueError as e:
+            raise click.ClickException(str(e)) from None
+
+        inventory.save(inventory_path)
+        click.echo(click.style(
+            f"  ok: eui …{vent.eui_short} | code {vent.manual_code} | {hint or '(no room hint)'}",
+            fg="green",
+        ))
+
+    click.echo("")
+    click.echo(click.style(
+        f"Wrote {len(inventory.vents)} vents to {inventory_path}",
+        bold=True,
+    ))
+
+
+# ---------------------------------------------------------------- labels
+@main.command()
+@click.option("--kit", required=True, type=str, help="Kit ID (subdir of --kit-root).")
+@click.option(
+    "--kit-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=DEFAULT_KIT_ROOT,
+)
+@click.option(
+    "--out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output PDF path (default: <kit>/labels.pdf).",
+)
+def labels_cmd(kit: str, kit_root: Path, out: Path | None) -> None:
+    """Render an Avery 5160 sheet of QR stickers for a kit."""
+    inv_path = kit_root / kit / "inventory.json"
+    if not inv_path.exists():
+        raise click.ClickException(f"inventory not found: {inv_path}")
+    if out is None:
+        out = kit_root / kit / "labels.pdf"
+    labels.render_pdf_from_path(inv_path, out)
+    click.echo(f"Wrote {out}")
+
+
+main.add_command(labels_cmd, name="labels")
+
+
+# -------------------------------------------------------------- kit-card
+@main.command(name="kit-card")
+@click.option("--kit", required=True, type=str)
+@click.option(
+    "--kit-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=DEFAULT_KIT_ROOT,
+)
+@click.option(
+    "--out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output PDF path (default: <kit>/kit-card.pdf).",
+)
+@click.option(
+    "--ap-password",
+    type=str,
+    default="",
+    help="If set, printed on the card as the first-boot AP-mode WiFi password.",
+)
+@click.option(
+    "--support-contact",
+    type=str,
+    default="support@example.com",
+    help="Support email or phone shown at the bottom of the card.",
+)
+def kit_card_cmd(
+    kit: str,
+    kit_root: Path,
+    out: Path | None,
+    ap_password: str,
+    support_contact: str,
+) -> None:
+    """Render a one-page client quick-start card."""
+    inv_path = kit_root / kit / "inventory.json"
+    if not inv_path.exists():
+        raise click.ClickException(f"inventory not found: {inv_path}")
+    if out is None:
+        out = kit_root / kit / "kit-card.pdf"
+    kit_card.render_pdf_from_path(
+        inv_path,
+        out,
+        ap_password=ap_password,
+        support_contact=support_contact,
+    )
+    click.echo(f"Wrote {out}")
+
+
+# --------------------------------------------------------------- helpers
+def _default_kit_id() -> str:
+    import uuid
+
+    today = datetime.date.today().isoformat()
+    return f"kit-{today}-{uuid.uuid4().hex[:6]}"
+
+
+def _split_rooms(spec: str | None) -> list[str]:
+    if not spec:
+        return []
+    return [s.strip() for s in spec.split(",") if s.strip()]
+
+
+def _load_or_create(
+    inventory_path: Path, kit_id: str, firmware_version: str
+) -> Inventory:
+    if inventory_path.exists():
+        existing = Inventory.load(inventory_path)
+        if existing.kit_id != kit_id:
+            click.echo(
+                click.style(
+                    f"warning: existing inventory has kit_id={existing.kit_id}, "
+                    f"continuing with that (your --kit-id={kit_id} is ignored)",
+                    fg="yellow",
+                ),
+                err=True,
+            )
+        return existing
+    return Inventory(kit_id=kit_id, firmware_version=firmware_version)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/provision/smart_vent_provision/devices.py
+++ b/tools/provision/smart_vent_provision/devices.py
@@ -1,0 +1,60 @@
+"""Enumerate connected ESP32-C6 boards (XIAO USB JTAG/serial)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import serial.tools.list_ports
+
+XIAO_VID = 0x303A  # Espressif
+XIAO_PID = 0x1001  # USB JTAG/serial debug unit
+
+
+@dataclass(frozen=True)
+class Board:
+    port: str  # /dev/ttyACM0
+    serial_number: str | None
+
+    def __str__(self) -> str:
+        return f"{self.port} (sn={self.serial_number or 'unknown'})"
+
+
+def enumerate_boards() -> list[Board]:
+    """Return all currently-attached XIAO ESP32-C6 boards.
+
+    Sorted by port path for deterministic ordering when multiple boards
+    are plugged into a hub.
+    """
+    boards: list[Board] = []
+    for port in serial.tools.list_ports.comports():
+        if port.vid == XIAO_VID and port.pid == XIAO_PID:
+            boards.append(Board(port=port.device, serial_number=port.serial_number))
+    boards.sort(key=lambda b: b.port)
+    return boards
+
+
+def find_single_board() -> Board:
+    """Convenience for the interactive flow: expect exactly one board."""
+    boards = enumerate_boards()
+    if not boards:
+        raise RuntimeError(
+            "no XIAO ESP32-C6 detected. Plug it directly into a USB port "
+            "(not through a hub) and confirm `lsusb -d 303a:` shows it."
+        )
+    if len(boards) > 1:
+        ports = ", ".join(b.port for b in boards)
+        raise RuntimeError(
+            f"more than one XIAO ESP32-C6 attached: {ports}. "
+            "Unplug all but the one you want to flash."
+        )
+    return boards[0]
+
+
+def find_existing_port(port: str | Path) -> Board:
+    """Return a Board for an explicit port path, or raise if not present."""
+    port = str(port)
+    for board in enumerate_boards():
+        if board.port == port:
+            return board
+    raise RuntimeError(f"no XIAO ESP32-C6 attached at {port}")

--- a/tools/provision/smart_vent_provision/flasher.py
+++ b/tools/provision/smart_vent_provision/flasher.py
@@ -1,0 +1,71 @@
+"""Drive `espflash` to write a firmware bundle to a connected XIAO."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from .release import FirmwareBundle
+
+
+class FlashError(RuntimeError):
+    """Raised when espflash exits non-zero."""
+
+
+def ensure_espflash() -> str:
+    """Return the path to espflash, or raise if not installed."""
+    path = shutil.which("espflash")
+    if not path:
+        raise FlashError(
+            "espflash not found on PATH. Install with `cargo install espflash --version '^3'`."
+        )
+    return path
+
+
+def flash(bundle: FirmwareBundle, *, port: str, chip: str | None = None) -> None:
+    """Flash the bundle to the board on `port`.
+
+    Uses the layout from the manifest: bootloader at its offset,
+    partition table at its offset, app at its offset. Matches the
+    runbook §5.3 piecemeal flow.
+    """
+    chip = chip or bundle.chip
+    espflash = ensure_espflash()
+
+    by_name = {entry.name: entry for entry in bundle.layout}
+    try:
+        bootloader = by_name["bootloader"].path
+        app = by_name["app"].path
+    except KeyError as exc:
+        raise FlashError(f"firmware bundle is missing required entry: {exc.args[0]}") from exc
+
+    partitions_csv = bundle.cache_dir / "partitions.csv"
+    if not partitions_csv.exists():
+        raise FlashError(f"partitions.csv missing from bundle cache: {partitions_csv}")
+
+    cmd = [
+        espflash,
+        "flash",
+        "--chip", chip,
+        "--port", port,
+        "--partition-table", str(partitions_csv),
+        "--bootloader", str(bootloader),
+        str(app),
+    ]
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        raise FlashError(f"espflash exited with code {result.returncode}")
+
+
+def write_merged_image(bundle: FirmwareBundle, output: Path) -> Path:
+    """Copy the merged single-image binary out of the cache to `output`.
+
+    Useful when the operator wants a single .bin to drag into a third-
+    party flasher (esptool.py, ESP Web Flasher, etc.) without dealing
+    with three separate offsets.
+    """
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(bundle.merged_image.read_bytes())
+    return output

--- a/tools/provision/smart_vent_provision/inventory.py
+++ b/tools/provision/smart_vent_provision/inventory.py
@@ -1,0 +1,62 @@
+"""Per-kit inventory model: the source of truth for what's in a kit.
+
+A kit's inventory.json is produced by `flash`, consumed by `labels`,
+`kit-card`, and `image`. JSON is intentionally hand-editable so the
+operator can fix a typo or add a room hint after the fact.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class Vent:
+    eui64: str
+    qr: str
+    manual_code: str
+    label_hint: str = ""
+
+    @property
+    def eui_short(self) -> str:
+        """Last 4 hex characters of the EUI-64, no separators.
+
+        Used on the printed label to match sticker to physical board.
+        """
+        cleaned = self.eui64.replace(":", "").replace("-", "").lower()
+        return cleaned[-4:]
+
+
+@dataclass
+class Inventory:
+    kit_id: str
+    firmware_version: str
+    hub_image_version: str = ""
+    vents: list[Vent] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, path: Path) -> "Inventory":
+        data = json.loads(Path(path).read_text())
+        return cls(
+            kit_id=data["kit_id"],
+            firmware_version=data["firmware_version"],
+            hub_image_version=data.get("hub_image_version", ""),
+            vents=[Vent(**v) for v in data.get("vents", [])],
+        )
+
+    def save(self, path: Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2) + "\n")
+
+    def add_vent(self, vent: Vent) -> None:
+        if any(v.eui64 == vent.eui64 for v in self.vents):
+            raise ValueError(f"vent with EUI-64 {vent.eui64} is already in the kit")
+        self.vents.append(vent)
+
+    def extend(self, vents: Iterable[Vent]) -> None:
+        for v in vents:
+            self.add_vent(v)

--- a/tools/provision/smart_vent_provision/kit_card.py
+++ b/tools/provision/smart_vent_provision/kit_card.py
@@ -1,0 +1,102 @@
+"""One-page client quick-start PDF.
+
+Bare-bones v1: kit ID, the AP-mode SSID/password placeholders, app
+store links, support line. Provider can customize text via CLI flags.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
+
+from .inventory import Inventory
+
+PAGE_W, PAGE_H = LETTER
+
+
+def render_pdf(
+    inventory: Inventory,
+    output: Path,
+    *,
+    ap_password: str = "",
+    support_contact: str = "support@example.com",
+) -> Path:
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    pdf = canvas.Canvas(str(output), pagesize=LETTER)
+
+    ap_ssid = f"smart-vent-setup-{inventory.kit_id[-4:]}"
+    n_vents = len(inventory.vents)
+
+    pdf.setFont("Helvetica-Bold", 28)
+    pdf.drawString(0.75 * inch, PAGE_H - 1.2 * inch, "Welcome to smart-vent")
+
+    pdf.setFont("Helvetica", 12)
+    cursor = PAGE_H - 1.7 * inch
+    line = lambda text, gap=0.25: (pdf.drawString(0.75 * inch, cursor, text), gap)
+
+    cursor -= 0.05 * inch
+    pdf.drawString(0.75 * inch, cursor, f"Your kit:  {inventory.kit_id}")
+    cursor -= 0.25 * inch
+    pdf.drawString(0.75 * inch, cursor, f"Includes:  {n_vents} vent{'s' if n_vents != 1 else ''}, 1 hub")
+    cursor -= 0.5 * inch
+
+    pdf.setFont("Helvetica-Bold", 16)
+    pdf.drawString(0.75 * inch, cursor, "1.  Plug in the hub")
+    cursor -= 0.30 * inch
+    pdf.setFont("Helvetica", 11)
+    pdf.drawString(0.95 * inch, cursor, "Power the hub from any USB-C charger. Wait ~30s for the LED.")
+    cursor -= 0.50 * inch
+
+    pdf.setFont("Helvetica-Bold", 16)
+    pdf.drawString(0.75 * inch, cursor, "2.  Connect it to your WiFi")
+    cursor -= 0.30 * inch
+    pdf.setFont("Helvetica", 11)
+    pdf.drawString(0.95 * inch, cursor, f"From your phone WiFi list, join:  {ap_ssid}")
+    cursor -= 0.20 * inch
+    if ap_password:
+        pdf.drawString(0.95 * inch, cursor, f"Password:  {ap_password}")
+        cursor -= 0.20 * inch
+    pdf.drawString(0.95 * inch, cursor, "Enter your home WiFi name and password when prompted, then wait for reboot.")
+    cursor -= 0.50 * inch
+
+    pdf.setFont("Helvetica-Bold", 16)
+    pdf.drawString(0.75 * inch, cursor, "3.  Install the smart-vent app")
+    cursor -= 0.30 * inch
+    pdf.setFont("Helvetica", 11)
+    pdf.drawString(0.95 * inch, cursor, "Search 'smart-vent' on the App Store or Google Play.")
+    cursor -= 0.50 * inch
+
+    pdf.setFont("Helvetica-Bold", 16)
+    pdf.drawString(0.75 * inch, cursor, "4.  Add each vent")
+    cursor -= 0.30 * inch
+    pdf.setFont("Helvetica", 11)
+    pdf.drawString(0.95 * inch, cursor, "In the app, tap 'Add vent' and scan the QR sticker on the vent.")
+    cursor -= 0.20 * inch
+    pdf.drawString(0.95 * inch, cursor, "Pick the room when prompted. Repeat for each vent.")
+    cursor -= 0.80 * inch
+
+    pdf.setFont("Helvetica-Oblique", 10)
+    pdf.drawString(0.75 * inch, cursor, f"Need help?  {support_contact}")
+
+    pdf.showPage()
+    pdf.save()
+    return output
+
+
+def render_pdf_from_path(
+    inventory_path: Path,
+    output: Path,
+    *,
+    ap_password: str = "",
+    support_contact: str = "support@example.com",
+) -> Path:
+    return render_pdf(
+        Inventory.load(inventory_path),
+        output,
+        ap_password=ap_password,
+        support_contact=support_contact,
+    )

--- a/tools/provision/smart_vent_provision/labels.py
+++ b/tools/provision/smart_vent_provision/labels.py
@@ -1,0 +1,106 @@
+"""Generate a per-kit sticker sheet (Avery 5160).
+
+Avery 5160: 30 labels per US-Letter page, 3 columns × 10 rows,
+1" × 2.625" each. Tight fit — but a QR with EC=M scaled to ~0.75"
+is still phone-scannable.
+
+Each sticker shows:
+  - QR code  (Matter payload, the only thing the mobile app cares about)
+  - Last 4 of EUI-64  (so operator can match sticker to physical board)
+  - Friendly label hint  ("study vent 1" etc.) when set on the Vent
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.units import inch
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfgen import canvas
+
+from .inventory import Inventory, Vent
+from .qr import render
+
+# Avery 5160 geometry.
+PAGE_W, PAGE_H = LETTER
+LABEL_W = 2.625 * inch
+LABEL_H = 1.0 * inch
+LABEL_COLS = 3
+LABEL_ROWS = 10
+HORIZONTAL_GAP = 0.125 * inch  # between columns
+SIDE_MARGIN = 0.1875 * inch    # outer left/right
+TOP_MARGIN = 0.5 * inch         # outer top (also bottom by symmetry)
+
+LABELS_PER_PAGE = LABEL_COLS * LABEL_ROWS
+
+
+def render_pdf(inventory: Inventory, output: Path) -> Path:
+    """Render `inventory.vents` onto an Avery 5160 sheet at `output`."""
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    pdf = canvas.Canvas(str(output), pagesize=LETTER)
+
+    for page_offset in range(0, len(inventory.vents), LABELS_PER_PAGE):
+        page_vents = inventory.vents[page_offset:page_offset + LABELS_PER_PAGE]
+        _draw_page(pdf, page_vents, inventory.kit_id)
+        pdf.showPage()
+
+    pdf.save()
+    return output
+
+
+def _draw_page(pdf: canvas.Canvas, vents: list[Vent], kit_id: str) -> None:
+    for slot, vent in enumerate(vents):
+        col = slot % LABEL_COLS
+        row = slot // LABEL_COLS
+
+        x = SIDE_MARGIN + col * (LABEL_W + HORIZONTAL_GAP)
+        # Y is measured from the bottom in ReportLab; row 0 is the
+        # top, so flip.
+        y = PAGE_H - TOP_MARGIN - (row + 1) * LABEL_H
+
+        _draw_label(pdf, x, y, vent, kit_id)
+
+
+def _draw_label(pdf: canvas.Canvas, x: float, y: float, vent: Vent, kit_id: str) -> None:
+    qr_size = 0.75 * inch
+    qr_padding = 0.05 * inch
+
+    pdf.setLineWidth(0.25)
+    pdf.rect(x, y, LABEL_W, LABEL_H, stroke=1, fill=0)
+
+    # QR code on the left
+    qr_img = render(vent.qr, box_size=8, border=2)
+    qr_buf = io.BytesIO()
+    qr_img.save(qr_buf, format="PNG")
+    qr_buf.seek(0)
+    pdf.drawImage(
+        ImageReader(qr_buf),
+        x + qr_padding,
+        y + (LABEL_H - qr_size) / 2,
+        width=qr_size,
+        height=qr_size,
+        preserveAspectRatio=True,
+    )
+
+    # Text on the right of the QR
+    text_x = x + qr_size + qr_padding * 2
+    text_top = y + LABEL_H - 0.18 * inch
+
+    pdf.setFont("Helvetica-Bold", 9)
+    pdf.drawString(text_x, text_top, "smart-vent")
+
+    pdf.setFont("Helvetica", 8)
+    pdf.drawString(text_x, text_top - 0.15 * inch, f"id …{vent.eui_short}")
+
+    label_hint = vent.label_hint or "room: ______________"
+    pdf.drawString(text_x, text_top - 0.30 * inch, label_hint)
+
+    pdf.setFont("Helvetica", 6)
+    pdf.drawString(text_x, y + 0.06 * inch, kit_id)
+
+
+def render_pdf_from_path(inventory_path: Path, output: Path) -> Path:
+    return render_pdf(Inventory.load(inventory_path), output)

--- a/tools/provision/smart_vent_provision/qr.py
+++ b/tools/provision/smart_vent_provision/qr.py
@@ -1,0 +1,29 @@
+"""Render a Matter QR-code payload string into a PIL Image.
+
+The standalone `tools/qr-generator/generate_qr.py` writes a PNG file;
+this module returns an in-memory image so the labels and kit-card
+modules can embed it into PDFs without a temp file dance.
+"""
+
+from __future__ import annotations
+
+import qrcode
+from qrcode.constants import ERROR_CORRECT_M
+
+
+def render(payload: str, *, box_size: int = 6, border: int = 2):
+    """Return a PIL Image of the QR code for the given Matter payload.
+
+    `box_size` is the pixel width of one QR module; `border` is in
+    modules. ERROR_CORRECT_M (~15%) is a good balance for printed
+    stickers — survives smudging but stays compact.
+    """
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=ERROR_CORRECT_M,
+        box_size=box_size,
+        border=border,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    return qr.make_image(fill_color="black", back_color="white").convert("RGB")

--- a/tools/provision/smart_vent_provision/release.py
+++ b/tools/provision/smart_vent_provision/release.py
@@ -1,0 +1,175 @@
+"""Fetch firmware release artifacts from GitHub Releases.
+
+The CI workflow on every firmware-v* tag publishes a release with:
+  bootloader.bin, partition-table.bin, vent-controller.bin,
+  vent-controller-merged.bin, partitions.csv, firmware-manifest.json
+
+This module downloads the set into a cache dir (under platformdirs)
+and verifies every file's sha256 against the manifest before returning
+the local paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import platformdirs
+import requests
+
+GITHUB_API = "https://api.github.com"
+REPO = "EtaCassiopeia/smart-vent"
+DEFAULT_CACHE_ROOT = Path(platformdirs.user_cache_dir("smart-vent")) / "firmware"
+
+# Files we expect in every firmware release.
+EXPECTED_FILES = (
+    "bootloader.bin",
+    "partition-table.bin",
+    "partitions.csv",
+    "vent-controller.bin",
+    "vent-controller-merged.bin",
+    "firmware-manifest.json",
+)
+
+
+@dataclass
+class FlashLayout:
+    """A single piece of the per-board flash, with its target offset."""
+
+    name: str  # "bootloader" | "partition_table" | "app"
+    path: Path  # local path to the binary
+    offset: str  # e.g. "0x0", "0x8000", "0x10000"
+
+
+@dataclass
+class FirmwareBundle:
+    version: str
+    commit: str
+    chip: str
+    idf_version: str
+    cache_dir: Path
+    layout: list[FlashLayout]
+    merged_image: Path
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.cache_dir / "firmware-manifest.json"
+
+
+class ReleaseError(RuntimeError):
+    """Raised when a release can't be fetched or verified."""
+
+
+def _resolve_tag(tag: str | None) -> str:
+    """Resolve None/`latest` to the actual latest firmware-v* tag."""
+    if tag and tag != "latest":
+        return tag
+    url = f"{GITHUB_API}/repos/{REPO}/releases"
+    resp = requests.get(url, params={"per_page": 30}, timeout=15)
+    resp.raise_for_status()
+    for rel in resp.json():
+        name = rel.get("tag_name", "")
+        if name.startswith("firmware-v") and not rel.get("draft") and not rel.get("prerelease"):
+            return name
+    raise ReleaseError("no published firmware-v* release found")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(64 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _download(asset_url: str, dest: Path, session: requests.Session) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with session.get(asset_url, stream=True, timeout=60) as r:
+        r.raise_for_status()
+        with dest.open("wb") as f:
+            for chunk in r.iter_content(chunk_size=64 * 1024):
+                if chunk:
+                    f.write(chunk)
+
+
+def fetch(tag: str | None = None, *, cache_root: Path | None = None) -> FirmwareBundle:
+    """Fetch (or load from cache) the firmware release for the given tag.
+
+    Verifies every binary's sha256 against the manifest. If the cache
+    is already populated and verifies clean, no network calls happen.
+    """
+    cache_root = cache_root or DEFAULT_CACHE_ROOT
+    resolved = _resolve_tag(tag)
+    cache_dir = cache_root / resolved
+
+    if not _cache_is_complete_and_valid(cache_dir):
+        _populate_cache(resolved, cache_dir)
+        _verify_cache(cache_dir)
+
+    return _build_bundle(cache_dir)
+
+
+def _cache_is_complete_and_valid(cache_dir: Path) -> bool:
+    if not all((cache_dir / f).exists() for f in EXPECTED_FILES):
+        return False
+    try:
+        _verify_cache(cache_dir)
+    except ReleaseError:
+        return False
+    return True
+
+
+def _populate_cache(tag: str, cache_dir: Path) -> None:
+    url = f"{GITHUB_API}/repos/{REPO}/releases/tags/{tag}"
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    rel = resp.json()
+    assets = {a["name"]: a["browser_download_url"] for a in rel.get("assets", [])}
+    missing = [f for f in EXPECTED_FILES if f not in assets]
+    if missing:
+        raise ReleaseError(f"release {tag} is missing assets: {', '.join(missing)}")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    with requests.Session() as session:
+        for name in EXPECTED_FILES:
+            _download(assets[name], cache_dir / name, session)
+
+
+def _verify_cache(cache_dir: Path) -> None:
+    manifest_path = cache_dir / "firmware-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for entry in manifest.get("flash", []):
+        local = cache_dir / entry["path"]
+        actual = _sha256(local)
+        if actual != entry["sha256"]:
+            raise ReleaseError(
+                f"sha256 mismatch for {entry['path']}: expected {entry['sha256']}, got {actual}"
+            )
+    merged = manifest.get("merged")
+    if merged:
+        local = cache_dir / merged["path"]
+        actual = _sha256(local)
+        if actual != merged["sha256"]:
+            raise ReleaseError(
+                f"sha256 mismatch for {merged['path']}: expected {merged['sha256']}, got {actual}"
+            )
+
+
+def _build_bundle(cache_dir: Path) -> FirmwareBundle:
+    manifest = json.loads((cache_dir / "firmware-manifest.json").read_text())
+    layout = [
+        FlashLayout(name=e["name"], path=cache_dir / e["path"], offset=e["offset"])
+        for e in manifest["flash"]
+    ]
+    merged = cache_dir / manifest["merged"]["path"]
+    return FirmwareBundle(
+        version=manifest["version"],
+        commit=manifest["commit"],
+        chip=manifest["chip"],
+        idf_version=manifest["idf_version"],
+        cache_dir=cache_dir,
+        layout=layout,
+        merged_image=merged,
+    )

--- a/tools/provision/smart_vent_provision/serial_capture.py
+++ b/tools/provision/smart_vent_provision/serial_capture.py
@@ -1,0 +1,89 @@
+"""Capture the firmware boot log to extract EUI-64, QR payload, and code.
+
+The firmware logs three lines we care about during its first 30 seconds:
+
+    I (1043)  Vent Controller v0.1.0
+    I (1234)  EUI-64: 58:e6:c5:01:0a:dc
+    I (2123)  Manual pairing code: 34970112332
+    I (2125)  QR code payload: MT:Y3...
+
+We read the serial port (115200, 8-N-1) and parse those lines. Time out
+after ~30s if we don't see what we need.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+
+import serial
+
+EUI64_RE = re.compile(r"EUI-64:\s*([0-9a-fA-F:]{17,23})")
+QR_RE = re.compile(r"QR code payload:\s*(MT:\S+)")
+CODE_RE = re.compile(r"Manual pairing code:\s*(\d{8,12})")
+BANNER_RE = re.compile(r"Vent Controller v")
+
+
+@dataclass
+class BootInfo:
+    eui64: str
+    qr: str
+    manual_code: str
+
+
+class CaptureTimeout(RuntimeError):
+    """Raised when we don't see all three values within the timeout."""
+
+
+def capture(port: str, *, baudrate: int = 115_200, timeout_s: float = 45.0) -> BootInfo:
+    """Open the serial port and read until we have all three fields.
+
+    Raises CaptureTimeout if we don't see them in `timeout_s` seconds
+    after the first banner line (which marks a fresh boot).
+    """
+    eui64: str | None = None
+    qr: str | None = None
+    code: str | None = None
+    banner_seen = False
+
+    deadline = time.monotonic() + timeout_s
+
+    with serial.Serial(port, baudrate=baudrate, timeout=1.0) as ser:
+        # Make sure we're starting from a fresh boot — drain stale data.
+        ser.reset_input_buffer()
+
+        while time.monotonic() < deadline:
+            line = ser.readline().decode("utf-8", errors="replace")
+            if not line:
+                continue
+
+            if BANNER_RE.search(line):
+                banner_seen = True
+
+            if eui64 is None:
+                m = EUI64_RE.search(line)
+                if m:
+                    eui64 = m.group(1).lower()
+            if qr is None:
+                m = QR_RE.search(line)
+                if m:
+                    qr = m.group(1)
+            if code is None:
+                m = CODE_RE.search(line)
+                if m:
+                    code = m.group(1)
+
+            if eui64 and qr and code:
+                if not banner_seen:
+                    # We grabbed all three but never saw a fresh-boot banner
+                    # — probably reading mid-stream from a long-running
+                    # device. Acceptable but worth noting upstream.
+                    pass
+                return BootInfo(eui64=eui64, qr=qr, manual_code=code)
+
+    missing = [name for name, val in (("eui64", eui64), ("qr", qr), ("code", code)) if val is None]
+    raise CaptureTimeout(
+        f"timed out after {timeout_s}s waiting for: {', '.join(missing)}. "
+        "Power-cycle the board (unplug + replug, NO BOOT-hold) to emit a fresh boot banner."
+    )

--- a/tools/provision/tests/test_inventory.py
+++ b/tools/provision/tests/test_inventory.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from smart_vent_provision.inventory import Inventory, Vent
+
+
+def test_vent_eui_short():
+    v = Vent(eui64="58:e6:c5:01:0a:dc", qr="MT:X", manual_code="123")
+    assert v.eui_short == "0adc"
+
+
+def test_vent_eui_short_handles_dash_separator():
+    v = Vent(eui64="58-e6-c5-01-0a-dc", qr="MT:X", manual_code="123")
+    assert v.eui_short == "0adc"
+
+
+def test_inventory_roundtrip(tmp_path: Path):
+    inv = Inventory(kit_id="kit-abc", firmware_version="firmware-v0.1.0")
+    inv.add_vent(Vent(eui64="58:e6:c5:01:0a:dc", qr="MT:A", manual_code="111"))
+    inv.add_vent(Vent(eui64="58:e6:c5:02:0a:dd", qr="MT:B", manual_code="222", label_hint="study"))
+
+    out = tmp_path / "kits" / "kit-abc" / "inventory.json"
+    inv.save(out)
+
+    raw = json.loads(out.read_text())
+    assert raw["kit_id"] == "kit-abc"
+    assert len(raw["vents"]) == 2
+
+    loaded = Inventory.load(out)
+    assert loaded.kit_id == "kit-abc"
+    assert loaded.vents[1].label_hint == "study"
+
+
+def test_inventory_rejects_duplicate_eui():
+    inv = Inventory(kit_id="k", firmware_version="v")
+    inv.add_vent(Vent(eui64="58:e6:c5:01:0a:dc", qr="MT:A", manual_code="111"))
+    with pytest.raises(ValueError):
+        inv.add_vent(Vent(eui64="58:e6:c5:01:0a:dc", qr="MT:B", manual_code="222"))

--- a/tools/provision/tests/test_labels.py
+++ b/tools/provision/tests/test_labels.py
@@ -1,0 +1,51 @@
+"""Sanity tests for the labels PDF generator.
+
+We don't visually verify — too brittle. We do confirm that the PDF
+is created, is non-empty, and starts with %PDF-.
+"""
+
+from pathlib import Path
+
+from smart_vent_provision.inventory import Inventory, Vent
+from smart_vent_provision.labels import render_pdf
+
+
+def _inventory(n: int) -> Inventory:
+    inv = Inventory(kit_id="kit-test", firmware_version="firmware-v0.1.0")
+    for i in range(n):
+        inv.add_vent(
+            Vent(
+                eui64=f"58:e6:c5:01:0a:{i:02x}",
+                qr=f"MT:TEST{i:03d}",
+                manual_code=f"{1000 + i}",
+                label_hint=f"room {i + 1}",
+            )
+        )
+    return inv
+
+
+def test_render_single_label(tmp_path: Path):
+    inv = _inventory(1)
+    out = tmp_path / "labels.pdf"
+    render_pdf(inv, out)
+    data = out.read_bytes()
+    assert data.startswith(b"%PDF-")
+    assert len(data) > 1024  # something more than an empty PDF
+
+
+def test_render_full_page_of_labels(tmp_path: Path):
+    inv = _inventory(30)
+    out = tmp_path / "labels.pdf"
+    render_pdf(inv, out)
+    assert out.read_bytes().startswith(b"%PDF-")
+
+
+def test_render_multipage(tmp_path: Path):
+    inv = _inventory(31)  # 30 on page 1, 1 on page 2
+    out = tmp_path / "labels.pdf"
+    render_pdf(inv, out)
+    # Both pages exist in a single PDF; we just need it to be longer
+    # than the single-page output.
+    single = tmp_path / "labels-single.pdf"
+    render_pdf(_inventory(30), single)
+    assert out.stat().st_size > single.stat().st_size

--- a/tools/provision/tests/test_qr.py
+++ b/tools/provision/tests/test_qr.py
@@ -1,0 +1,16 @@
+from smart_vent_provision.qr import render
+
+
+def test_renders_a_pil_rgb_image():
+    img = render("MT:Y3.13OTB00KA0648G00")
+    assert img.mode == "RGB"
+    # QR codes should be square.
+    assert img.size[0] == img.size[1]
+    # And big enough to scan from a phone — sanity floor.
+    assert img.size[0] >= 100
+
+
+def test_box_size_scales_image():
+    small = render("MT:X", box_size=2, border=1)
+    big = render("MT:X", box_size=10, border=1)
+    assert big.size[0] > small.size[0]

--- a/tools/provision/tests/test_release.py
+++ b/tools/provision/tests/test_release.py
@@ -1,0 +1,143 @@
+"""Test release.fetch — the GitHub release downloader.
+
+Uses `responses` to mock the GitHub API + asset downloads. Verifies:
+  - resolves "latest" tag
+  - downloads expected file set
+  - sha256-verifies against the manifest
+  - raises ReleaseError on mismatch
+  - re-fetch hits the cache
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import responses
+
+from smart_vent_provision import release as rel
+
+
+SAMPLE_BOOTLOADER = b"BOOTLOADER" * 8
+SAMPLE_PARTITIONS_BIN = b"PARTITIONS" * 4
+SAMPLE_APP = b"APP" * 64
+SAMPLE_MERGED = b"MERGED" * 64
+SAMPLE_PARTITIONS_CSV = b"# partition table\nnvs, data, nvs, 0x9000, 0x6000\n"
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _manifest_bytes() -> bytes:
+    return json.dumps(
+        {
+            "version": "firmware-v0.1.0",
+            "commit": "deadbeefcafe1234567890abcdef0123456789ab",
+            "chip": "esp32c6",
+            "idf_version": "v5.2.3",
+            "flash": [
+                {"name": "bootloader", "path": "bootloader.bin", "offset": "0x0", "sha256": _sha(SAMPLE_BOOTLOADER)},
+                {"name": "partition_table", "path": "partition-table.bin", "offset": "0x8000", "sha256": _sha(SAMPLE_PARTITIONS_BIN)},
+                {"name": "app", "path": "vent-controller.bin", "offset": "0x10000", "sha256": _sha(SAMPLE_APP)},
+            ],
+            "merged": {"path": "vent-controller-merged.bin", "offset": "0x0", "sha256": _sha(SAMPLE_MERGED)},
+        }
+    ).encode()
+
+
+def _register_release(tag: str) -> None:
+    base = f"https://example.com/{tag}"
+    payloads = {
+        "bootloader.bin": SAMPLE_BOOTLOADER,
+        "partition-table.bin": SAMPLE_PARTITIONS_BIN,
+        "partitions.csv": SAMPLE_PARTITIONS_CSV,
+        "vent-controller.bin": SAMPLE_APP,
+        "vent-controller-merged.bin": SAMPLE_MERGED,
+        "firmware-manifest.json": _manifest_bytes(),
+    }
+    assets = [
+        {"name": name, "browser_download_url": f"{base}/{name}"}
+        for name in payloads
+    ]
+    responses.add(
+        responses.GET,
+        f"{rel.GITHUB_API}/repos/{rel.REPO}/releases/tags/{tag}",
+        json={"tag_name": tag, "assets": assets},
+    )
+    for name, body in payloads.items():
+        responses.add(responses.GET, f"{base}/{name}", body=body, status=200)
+
+
+@responses.activate
+def test_fetch_explicit_tag_downloads_and_verifies(tmp_path: Path):
+    _register_release("firmware-v0.1.0")
+    bundle = rel.fetch("firmware-v0.1.0", cache_root=tmp_path)
+
+    assert bundle.version == "firmware-v0.1.0"
+    assert bundle.chip == "esp32c6"
+    assert {entry.name for entry in bundle.layout} == {"bootloader", "partition_table", "app"}
+    for entry in bundle.layout:
+        assert entry.path.exists()
+    assert bundle.merged_image.read_bytes() == SAMPLE_MERGED
+
+
+@responses.activate
+def test_fetch_cached_skips_network(tmp_path: Path):
+    _register_release("firmware-v0.1.0")
+    rel.fetch("firmware-v0.1.0", cache_root=tmp_path)
+
+    # Wipe registered responses; a second fetch should not hit the network.
+    responses.reset()
+    bundle = rel.fetch("firmware-v0.1.0", cache_root=tmp_path)
+    assert bundle.version == "firmware-v0.1.0"
+
+
+@responses.activate
+def test_fetch_resolves_latest_to_published_release(tmp_path: Path):
+    _register_release("firmware-v0.2.0")
+    # The releases-list lookup is what "latest" goes through:
+    responses.add(
+        responses.GET,
+        f"{rel.GITHUB_API}/repos/{rel.REPO}/releases",
+        json=[
+            {"tag_name": "hub-v0.1.0", "draft": False, "prerelease": False},
+            {"tag_name": "firmware-v0.2.0", "draft": False, "prerelease": False},
+            {"tag_name": "firmware-v0.1.0", "draft": False, "prerelease": False},
+        ],
+    )
+    bundle = rel.fetch(None, cache_root=tmp_path)
+    # The bundle's `version` is read from the manifest body, which is
+    # always "firmware-v0.1.0" in the helper. The real assertion of
+    # "latest" resolution is that the cache was created under the
+    # resolved tag dir.
+    assert bundle.cache_dir == tmp_path / "firmware-v0.2.0"
+
+
+@responses.activate
+def test_fetch_raises_on_sha256_mismatch(tmp_path: Path):
+    tag = "firmware-v0.1.0"
+    _register_release(tag)
+    # Replace the bootloader response with corrupted bytes.
+    responses.remove(responses.GET, f"https://example.com/{tag}/bootloader.bin")
+    responses.add(
+        responses.GET,
+        f"https://example.com/{tag}/bootloader.bin",
+        body=b"CORRUPTED",
+        status=200,
+    )
+    with pytest.raises(rel.ReleaseError):
+        rel.fetch(tag, cache_root=tmp_path)
+
+
+@responses.activate
+def test_fetch_raises_when_release_missing_files(tmp_path: Path):
+    responses.add(
+        responses.GET,
+        f"{rel.GITHUB_API}/repos/{rel.REPO}/releases/tags/firmware-v0.1.0",
+        json={"tag_name": "firmware-v0.1.0", "assets": []},
+    )
+    with pytest.raises(rel.ReleaseError):
+        rel.fetch("firmware-v0.1.0", cache_root=tmp_path)


### PR DESCRIPTION
## Summary

Workstream D of the deployment plan. Provider-side Python CLI (`smart-vent-provision`) that turns a tagged firmware release into a printed kit. **Phases are separate by design** — flashing is not commissioning, and the provider does not assign rooms.

| Phase | Owned by | Command | What it does |
|---|---|---|---|
| Flash | Provider | `smart-vent-provision flash` | Pulls the firmware release from GitHub (sha256-verified against `firmware-manifest.json`) and runs `espflash`. Nothing else. |
| Capture | Provider | `smart-vent-provision capture` | Reads the post-boot serial log of one board, records EUI-64 + Matter QR + manual pairing code into `kits/<kit-id>/inventory.json`. |
| Batch | Provider | `smart-vent-provision batch` | Convenience wrapper that walks `flash` + `capture` back-to-back per board. |
| Labels | Provider | `smart-vent-provision labels` | Inventory → Avery 5160 sticker sheet (QR + last-4 of EUI + optional cosmetic hint). |
| Quick-start | Provider | `smart-vent-provision kit-card` | Inventory → one-page client quick-start PDF (welcome, AP-mode SSID, install steps, support). |
| **Commission** | **Client (mobile app)** | n/a | **Scans the sticker QR, pairs into the client's Matter fabric on the hub, picks the room/floor.** Not done by this CLI. The mobile app is a separate Flutter project that talks to matter-server's WS API + HA REST. |

## Architecture decisions

- **Phase split.** `flash` only writes firmware bits — no inventory, no rooms. `capture` is a separate command that pulls the boot-log values needed for printing. `--label-hint` is purely the text printed on the sticker; it does not assign the vent to anything. (This replaces an earlier draft that had `flash --rooms`, which falsely conflated the two phases — see commit `6f16ff7` for the refactor.)
- **GitHub Releases as the artifact store**, consumed via the manifest's sha256s. No on-Pi compilation. Honors the design plan workstream-1 contract from PR #33.
- **Sequential, not parallel.** BOOT-hold dance is still manual per board (no flash jig yet). Realistic operator timing per the plan: <30 s/board after the first.
- **Hand-editable JSON inventory.** The PDF generators read it verbatim; operator can correct typos or add cosmetic hints after the fact.

## Out of scope (called out in the README)

- `image` subcommand (write SD card) → depends on the hub image, which is PR C / workstream-3.
- Per-vent unique passcodes → v2 via `mfg_tool` + per-device factory NVS partitions. v1 stays on the SDK-default passcode (matches the runbook §8 current behavior).
- Parallel flash via jig → future hardware investment per plan §5.1.
- Mobile app → separate Flutter repo, not built here.

## Test plan

- [x] 14 pytest passing (inventory roundtrip; release fetch + sha256 verify with mocked GitHub; QR rendering; PDF generation). No hardware needed for tests.
- [x] Live `release.fetch('firmware-v0.1.0')` against the real GH release: 6 files downloaded + sha256-verified, sizes match (~22 KB bootloader, ~3 KB partition table, ~2 MB app, ~4 MB merged).
- [x] PDF smoke test with a 3-vent synthetic inventory: both `labels.pdf` and `kit-card.pdf` produced.
- [x] CLI surface verified post-refactor: `flash --help`, `capture --help`, `batch --help`, `labels --help`, `kit-card --help` all parse and document the right scope.
- [ ] **Operator-driven smoke (you):** `pip install -e tools/provision[dev]`, plug a XIAO into the Pi, run `smart-vent-provision batch --count 1` — confirms the BOOT-hold prompt → espflash → power-cycle prompt → boot-banner capture chain works end-to-end and produces a clean inventory entry.
- [ ] Reviewer: open `labels.pdf` from the smoke run and confirm the QR scans from a phone.

## Follow-ups (separate PRs)

- Wire `tools/provision/` into a CI workflow (`provision.yml`) that publishes a wheel on `provision-v*` tags.
- PR B (Pi runtime: compose + first-boot wizard) and PR C (SD image bake) remain.
