### PR TITLE
Add provision CLI build/test/release workflow

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,0 +1,72 @@
+name: Provision CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/provision/**'
+      - '.github/workflows/provision.yml'
+    tags: ['provision-v*']
+  pull_request:
+    paths:
+      - 'tools/provision/**'
+      - '.github/workflows/provision.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: provision-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: write   # softprops/action-gh-release needs this on tag builds
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: tools/provision
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tools/provision/pyproject.toml
+
+      - name: Install build + test deps
+        run: |
+          python -m pip install --upgrade pip build
+          pip install -e ".[dev]"
+
+      - name: Tests
+        run: pytest -q
+
+      - name: Build wheel + sdist
+        run: python -m build --outdir dist
+
+      - name: Inventory build output
+        run: ls -la dist
+
+      - name: Upload build artifacts (PR + branch builds)
+        uses: actions/upload-artifact@v4
+        with:
+          name: provision-${{ github.sha }}
+          path: tools/provision/dist/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/provision-v')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            tools/provision/dist/*.whl
+            tools/provision/dist/*.tar.gz


### PR DESCRIPTION
Follow-up to PR #36: makes the smart-vent-provision CLI installable
without a repo checkout.

## What it does

- On PRs and main pushes that touch \`tools/provision/**\`: runs
  pytest, builds the wheel + sdist, uploads them as a 14-day GitHub
  Actions build artifact.
- On tags matching \`provision-v*\`: additionally publishes the wheel
  + sdist as assets on a GitHub Release (via softprops/action-gh-release@v2,
  same as firmware.yml).

After this lands and the first \`provision-v0.1.0\` tag is cut:

\`\`\`bash
pip install https://github.com/EtaCassiopeia/smart-vent/releases/download/provision-v0.1.0/smart_vent_provision-0.1.0-py3-none-any.whl
smart-vent-provision --version
\`\`\`

No source checkout required.

## Test plan

- [ ] PR CI run goes green (pytest + build wheel).
- [ ] After merge, push tag \`provision-v0.1.0\` -> release lands with
  the wheel + sdist attached.
- [ ] \`pip install <wheel-url>\` works in a fresh venv, \`smart-vent-provision --help\` runs.