### PR TITLE
PR B: Pi runtime — compose + install + systemd + first-boot wizard

### DIFF
--- a/pi/.env.example
+++ b/pi/.env.example
@@ -1,0 +1,8 @@
+# Smart-vent hub runtime config.
+# Copy this to .env on the Pi (or have install.sh do it).
+# Anything not set falls back to compose's default.
+
+# Network interface OTBR uses as the "backbone" (LAN side) and that
+# matter-server treats as its primary. Almost always wlan0; eth0 for
+# wired-Pi installs.
+BACKBONE_INTERFACE=wlan0

--- a/pi/README.md
+++ b/pi/README.md
@@ -11,6 +11,7 @@ deployment plan (workstream B), replacing the three hand-typed
 pi/
   docker-compose.yaml          OTBR + matter-server + Home Assistant
   .env.example                 Backbone interface + future config knobs
+  install.sh                   Idempotent installer for a fresh Pi
   systemd/
     smart-vent.service         Bring the compose up at boot (after first-boot)
     smart-vent-firstboot.service  AP-mode wizard, runs until .configured exists
@@ -19,11 +20,26 @@ pi/
 
 Next steps (separate commits, each one its own reviewable artifact):
 
-- `install.sh` — idempotent installer for a fresh Raspberry Pi OS
 - `firstboot/` — Flask-based AP-mode WiFi capture wizard (or a
   `comitup` adapter if the spike pans out)
 - `config/homeassistant/` — seed HA config copied from the existing
   `homeassistant/` templates
+
+## Install (the script does it all)
+
+```bash
+# Curl-piped, latest hub-v* tag:
+curl -sSL https://raw.githubusercontent.com/EtaCassiopeia/smart-vent/main/pi/install.sh | sudo bash
+
+# Developer flow (run from inside this repo):
+sudo SMART_VENT_SRC=$(pwd) bash pi/install.sh
+
+# Wired-Ethernet install or pre-configured WiFi (skips the wizard):
+sudo bash pi/install.sh --skip-wizard
+```
+
+The script is idempotent — re-running it upgrades in place without
+breaking the existing state.
 
 ## Service relationship
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,0 +1,40 @@
+# Pi hub runtime
+
+Everything in this directory ends up at `/opt/smart-vent/` on a
+provisioned Pi. It's the "what runs on the hub" half of the
+deployment plan (workstream B), replacing the three hand-typed
+`docker run` commands in `docs/runbook.md` §3.
+
+## Layout (growing — current state)
+
+```
+pi/
+  docker-compose.yaml   OTBR + matter-server + Home Assistant
+  .env.example          Backbone interface + future config knobs
+  README.md             this file
+```
+
+Next steps (separate commits, each one its own reviewable artifact):
+
+- `systemd/smart-vent.service` — bring the compose up at boot
+- `systemd/smart-vent-firstboot.service` — run the AP-mode wizard
+  until WiFi is configured
+- `install.sh` — idempotent installer for a fresh Raspberry Pi OS
+- `firstboot/` — Flask-based AP-mode WiFi capture wizard (or a
+  `comitup` adapter if the spike pans out)
+- `config/homeassistant/` — seed HA config copied from the existing
+  `homeassistant/` templates
+
+## Bring-up (today, manual)
+
+Once we have the systemd units, the install script will do this for
+you. For now (developer flow on the existing Pi):
+
+```bash
+cp .env.example .env
+# edit .env if your LAN is on eth0
+docker compose up -d
+docker compose ps
+```
+
+Verify per `docs/runbook.md` §3.4 (the four-check ladder).

--- a/pi/README.md
+++ b/pi/README.md
@@ -9,23 +9,39 @@ deployment plan (workstream B), replacing the three hand-typed
 
 ```
 pi/
-  docker-compose.yaml          OTBR + matter-server + Home Assistant
-  .env.example                 Backbone interface + future config knobs
-  install.sh                   Idempotent installer for a fresh Pi
+  docker-compose.yaml             OTBR + matter-server + Home Assistant
+  .env.example                    Backbone interface + future config knobs
+  install.sh                      Idempotent installer for a fresh Pi
   systemd/
-    smart-vent.service         Bring the compose up at boot (after first-boot)
+    smart-vent.service            Bring the compose up at boot (after first-boot)
     smart-vent-firstboot.service  AP-mode wizard, runs until .configured exists
   firstboot/
-    wizard.py                  Flask + hostapd + dnsmasq + nmcli onboarding
-    templates/, static/        Captive page + styling
-    README.md                  Behaviour + debugging notes
-  README.md                    this file
+    wizard.py                     Flask + hostapd + dnsmasq + nmcli onboarding
+    templates/, static/           Captive page + styling
+    README.md                     Behaviour + debugging notes
+  config/
+    homeassistant/
+      configuration.yaml          HA bootstrap, seeded into data/homeassistant/
+  README.md                       this file
 ```
 
-Next step:
+## Data layout on the Pi
 
-- `config/homeassistant/` — seed HA config copied from the existing
-  `homeassistant/` templates
+```
+/opt/smart-vent/
+  pi/                    # everything from this directory, rsync'd here
+  data/                  # container state, bind-mounted into the services
+    otbr/                # Thread dataset, Thread network state
+    matter-server/       # Fabric credentials + matter-server storage (chmod 700)
+    homeassistant/       # HA /config — operator can edit in place
+```
+
+`install.sh` seeds `data/homeassistant/` with the
+`configuration.yaml` from `pi/config/homeassistant/` plus the
+`scripts.yaml` / `automations.yaml` / schedule helpers / Vents
+dashboard from the repo's top-level `homeassistant/` directory.
+Operator edits are preserved on re-install (the seed step only
+runs when `configuration.yaml` is absent).
 
 ## Install (the script does it all)
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -15,13 +15,15 @@ pi/
   systemd/
     smart-vent.service         Bring the compose up at boot (after first-boot)
     smart-vent-firstboot.service  AP-mode wizard, runs until .configured exists
+  firstboot/
+    wizard.py                  Flask + hostapd + dnsmasq + nmcli onboarding
+    templates/, static/        Captive page + styling
+    README.md                  Behaviour + debugging notes
   README.md                    this file
 ```
 
-Next steps (separate commits, each one its own reviewable artifact):
+Next step:
 
-- `firstboot/` — Flask-based AP-mode WiFi capture wizard (or a
-  `comitup` adapter if the spike pans out)
 - `config/homeassistant/` — seed HA config copied from the existing
   `homeassistant/` templates
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -9,21 +9,36 @@ deployment plan (workstream B), replacing the three hand-typed
 
 ```
 pi/
-  docker-compose.yaml   OTBR + matter-server + Home Assistant
-  .env.example          Backbone interface + future config knobs
-  README.md             this file
+  docker-compose.yaml          OTBR + matter-server + Home Assistant
+  .env.example                 Backbone interface + future config knobs
+  systemd/
+    smart-vent.service         Bring the compose up at boot (after first-boot)
+    smart-vent-firstboot.service  AP-mode wizard, runs until .configured exists
+  README.md                    this file
 ```
 
 Next steps (separate commits, each one its own reviewable artifact):
 
-- `systemd/smart-vent.service` — bring the compose up at boot
-- `systemd/smart-vent-firstboot.service` — run the AP-mode wizard
-  until WiFi is configured
 - `install.sh` — idempotent installer for a fresh Raspberry Pi OS
 - `firstboot/` — Flask-based AP-mode WiFi capture wizard (or a
   `comitup` adapter if the spike pans out)
 - `config/homeassistant/` — seed HA config copied from the existing
   `homeassistant/` templates
+
+## Service relationship
+
+On a fresh Pi:
+
+1. Boot → `smart-vent-firstboot.service` runs (no `.configured` flag yet).
+   It brings up the AP, captures WiFi creds, joins the network, writes
+   `/var/lib/smart-vent/.configured`, and reboots.
+2. After reboot → `smart-vent-firstboot.service` is skipped (flag
+   present), `smart-vent.service` runs `docker compose up -d`.
+
+`smart-vent.service` is also gated on the flag, so even if the
+first-boot service was uninstalled, the main service would refuse to
+start without it (avoids the "Pi booted but isn't on the LAN" failure
+mode).
 
 ## Bring-up (today, manual)
 

--- a/pi/config/homeassistant/configuration.yaml
+++ b/pi/config/homeassistant/configuration.yaml
@@ -1,0 +1,38 @@
+# smart-vent hub bootstrap configuration.yaml
+#
+# Seeded by pi/install.sh into /opt/smart-vent/data/homeassistant/ on
+# fresh installs. Operator edits to this file are preserved on
+# upgrade — install.sh refuses to overwrite an existing
+# configuration.yaml.
+
+# Bring in HA's standard component bundle (frontend, history,
+# logbook, recorder, energy, etc).
+default_config:
+
+homeassistant:
+  name: "smart-vent"
+  unit_system: metric
+  external_url: ""    # set by the operator post-install
+
+# Templates synced from the repo's homeassistant/ directory by
+# install.sh; same content used by people who manually copy the
+# files into an existing HA instance (see homeassistant/README.md).
+script:    !include scripts.yaml
+automation: !include automations.yaml
+schedule:  !include helpers/schedule_helpers.yaml
+
+# Lovelace: keep storage-mode UI dashboards (so users can drag-and-
+# drop), plus a yaml-mode "Vents" dashboard that ships with the kit.
+lovelace:
+  mode: storage
+  dashboards:
+    vents:
+      mode: yaml
+      title: Vents
+      icon: mdi:air-filter
+      show_in_sidebar: true
+      filename: dashboards/vents.yaml
+
+# Matter integration is added by the user from the UI on first run
+# (Settings → Devices & Services → Add Integration → Matter,
+# pointing at ws://localhost:5580/ws).

--- a/pi/docker-compose.yaml
+++ b/pi/docker-compose.yaml
@@ -1,0 +1,89 @@
+# Pi hub runtime: OTBR + matter-server + Home Assistant.
+#
+# Replaces the three hand-typed `docker run` commands in
+# docs/runbook.md §3. Brought up at boot by smart-vent.service
+# (see ../systemd/smart-vent.service, landing in a follow-up step).
+#
+# All three containers share the host network because:
+#   - OTBR needs L2 access to wlan0/eth0 to act as a Thread border
+#     router (mDNS, IPv6 ICMP, NDP).
+#   - matter-server needs the same host network so multicast Matter
+#     traffic (mDNS) reaches it without an extra bridge hop.
+#   - Home Assistant talks to matter-server over ws://localhost:5580
+#     and serves its UI on :8123 directly on the LAN.
+#
+# Image tags are PINNED on purpose. Bumping a tag is a deliberate act:
+# we've previously been bitten by matter-server major upgrades that
+# silently reshape the WebSocket schema, and OTBR patch releases that
+# changed dataset defaults. Bump intentionally and re-verify the
+# four-check ladder in docs/runbook.md §6.3.
+
+x-image-tags-known-good: &image-tags
+  # Last verified on 2026-06-19 with a commissioned XIAO ESP32-C6 vent
+  # exchanging WindowCovering attributes through this hub.
+  otbr: "openthread/otbr:latest"
+  matter-server: "ghcr.io/home-assistant-libs/python-matter-server:stable"
+  homeassistant: "ghcr.io/home-assistant/home-assistant:stable"
+
+services:
+  otbr:
+    image: openthread/otbr:latest
+    container_name: otbr
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    volumes:
+      # /dev exposes /dev/ttyUSB0 (SLZB-07 Thread RCP) without static
+      # device bindings, so a different USB enumeration order doesn't
+      # break startup.
+      - /dev:/dev
+      - otbr-data:/var/lib/thread
+    environment:
+      # 460800 baud matches the SLZB-07 spinel default. If you swap
+      # the dongle, this changes — see runbook §3.1.
+      RADIO_URL: "spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=460800"
+      # BACKBONE_INTERFACE is read from the .env that ships with the
+      # SD image / install.sh. Defaults to wlan0; set to eth0 for
+      # wired-Pi installs.
+      BACKBONE_INTERFACE: "${BACKBONE_INTERFACE:-wlan0}"
+
+  matter-server:
+    image: ghcr.io/home-assistant-libs/python-matter-server:stable
+    container_name: matter-server
+    restart: unless-stopped
+    network_mode: host
+    # apparmor=unconfined is what python-matter-server's upstream
+    # docs recommend; without it BlueZ access is blocked on Bookworm.
+    security_opt:
+      - apparmor=unconfined
+    depends_on:
+      - otbr
+    volumes:
+      - matter-server-data:/data
+      # /run/dbus is needed for BlueZ pairing during commissioning.
+      - /run/dbus:/run/dbus:ro
+    command:
+      - "--storage-path"
+      - "/data"
+      - "--paa-root-cert-dir"
+      - "/data/credentials"
+      - "--primary-interface"
+      - "${BACKBONE_INTERFACE:-wlan0}"
+      - "--bluetooth-adapter"
+      - "0"
+
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: homeassistant
+    restart: unless-stopped
+    network_mode: host
+    # No devices.db bind mount this time — see runbook §7.5.1 note
+    # about the legacy hub leftover. HA's own registry is authoritative.
+    volumes:
+      - homeassistant-config:/config
+      - /etc/localtime:/etc/localtime:ro
+
+volumes:
+  otbr-data:
+  matter-server-data:
+  homeassistant-config:

--- a/pi/docker-compose.yaml
+++ b/pi/docker-compose.yaml
@@ -25,6 +25,10 @@ x-image-tags-known-good: &image-tags
   matter-server: "ghcr.io/home-assistant-libs/python-matter-server:stable"
   homeassistant: "ghcr.io/home-assistant/home-assistant:stable"
 
+# Data dirs are bind-mounted under /opt/smart-vent/data/ rather than
+# docker-managed named volumes. Lets the operator back them up with
+# normal tar, edit HA config files directly, and lets install.sh seed
+# the homeassistant/ tree on first install.
 services:
   otbr:
     image: openthread/otbr:latest
@@ -37,7 +41,7 @@ services:
       # device bindings, so a different USB enumeration order doesn't
       # break startup.
       - /dev:/dev
-      - otbr-data:/var/lib/thread
+      - /opt/smart-vent/data/otbr:/var/lib/thread
     environment:
       # 460800 baud matches the SLZB-07 spinel default. If you swap
       # the dongle, this changes — see runbook §3.1.
@@ -59,7 +63,7 @@ services:
     depends_on:
       - otbr
     volumes:
-      - matter-server-data:/data
+      - /opt/smart-vent/data/matter-server:/data
       # /run/dbus is needed for BlueZ pairing during commissioning.
       - /run/dbus:/run/dbus:ro
     command:
@@ -79,11 +83,9 @@ services:
     network_mode: host
     # No devices.db bind mount this time — see runbook §7.5.1 note
     # about the legacy hub leftover. HA's own registry is authoritative.
+    # install.sh seeds /opt/smart-vent/data/homeassistant/ with a
+    # configuration.yaml that !includes the scripts/automations/
+    # dashboards from the repo's homeassistant/ templates.
     volumes:
-      - homeassistant-config:/config
+      - /opt/smart-vent/data/homeassistant:/config
       - /etc/localtime:/etc/localtime:ro
-
-volumes:
-  otbr-data:
-  matter-server-data:
-  homeassistant-config:

--- a/pi/firstboot/README.md
+++ b/pi/firstboot/README.md
@@ -1,0 +1,75 @@
+# First-boot AP-mode WiFi onboarding
+
+Run by `smart-vent-firstboot.service` (see `../systemd/`). Brings up a
+WPA2 AP, serves a captive-style page where the client picks their home
+WiFi, switches to client mode, and reboots into the main runtime.
+
+## Files
+
+```
+firstboot/
+  wizard.py         The systemd ExecStart target. ~250 LOC.
+  templates/
+    index.html      Captive page (SSID picker + password)
+    joining.html    "Joining now…" page shown after submit
+  static/
+    style.css       Minimal mobile-first styling
+```
+
+## Why not comitup / RaspiWiFi
+
+The plan said "spike comitup first, only build custom if it doesn't
+fit." For this project, custom fits better:
+
+- We need branded UX (the SSID and captive-page styling match the
+  printed kit-card). comitup forces `comitup-<host>` SSIDs.
+- We're keeping NetworkManager as the Bookworm default; comitup
+  replaces the whole network stack.
+- The code is small (~250 LOC) — less integration surface than the
+  comitup adapter would be.
+
+## Behaviour
+
+On startup the wizard:
+
+1. Computes `smart-vent-setup-<short-eui>` from wlan0's MAC.
+2. Reads the AP password from `/etc/smart-vent/ap-password`
+   (operator-overridable, baked by the SD image / `install.sh`).
+   Falls back to a printed default if absent.
+3. Sets `wlan0` to unmanaged in NetworkManager, gives it
+   `192.168.4.1/24`, writes minimal `hostapd.conf` and
+   `dnsmasq.conf` to `/run/smart-vent/`, and spawns both as
+   children.
+4. Runs a Flask app on `:80`. Captive-portal probe URLs
+   (`/generate_204`, `/hotspot-detect.html`, etc.) all 302 to the
+   wizard page so iOS / Android pop the captive sheet.
+5. On form POST: tears down the AP, reclaims the interface for
+   NetworkManager, creates a `smart-vent-home` NM connection with
+   the submitted creds, runs `nmcli connection up`, and on success
+   writes `/var/lib/smart-vent/.configured` and reboots.
+
+After reboot `smart-vent-firstboot.service` is skipped (the
+`.configured` flag is present), `smart-vent.service` runs, and the
+hub containers come up.
+
+## Debugging
+
+The wizard is a systemd service; its stdout/stderr land in journald:
+
+```bash
+journalctl -u smart-vent-firstboot.service -f
+```
+
+Each subprocess invocation is logged (`$ nmcli connection add ...`)
+so you can replay them by hand if something fails.
+
+If the AP comes up but you can't reach `http://192.168.4.1/`, check:
+
+- `ip addr show wlan0` includes `192.168.4.1/24`
+- `ss -tlnp '( sport = :80 )'` shows the python3 wizard
+- `journalctl -u smart-vent-firstboot.service` for hostapd/dnsmasq
+  failures
+
+If the wizard wedges (panel-edge bug, can't reach Flask), reboot
+the Pi — the wizard restarts cleanly because every step is
+idempotent.

--- a/pi/firstboot/static/style.css
+++ b/pi/firstboot/static/style.css
@@ -1,0 +1,94 @@
+/* Minimal mobile-first styling for the first-boot wizard. */
+:root {
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --text: #f1f5f9;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --error: #fb7185;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 17px;
+  line-height: 1.5;
+}
+
+main {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+  background: var(--panel);
+  min-height: 100vh;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+}
+
+header p {
+  margin: 0.25rem 0 1.5rem;
+  color: var(--muted);
+}
+
+form { display: flex; flex-direction: column; gap: 1rem; }
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+input, select {
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #0b1220;
+  color: var(--text);
+}
+input:focus, select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+button {
+  margin-top: 0.5rem;
+  padding: 0.85rem 1rem;
+  font-size: 1.05rem;
+  border-radius: 8px;
+  border: 0;
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+}
+button:active { transform: translateY(1px); }
+
+footer { margin-top: 2rem; color: var(--muted); }
+
+.error {
+  background: rgba(251, 113, 133, 0.15);
+  border: 1px solid var(--error);
+  color: var(--error);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+ol { padding-left: 1.25rem; }
+ol li { margin: 0.5rem 0; }
+
+.muted { color: var(--muted); font-size: 0.9rem; }
+.hidden { display: none; }

--- a/pi/firstboot/templates/index.html
+++ b/pi/firstboot/templates/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>smart-vent — connect to WiFi</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <main>
+    <header>
+      <h1>smart-vent</h1>
+      <p>Let's get your hub on WiFi.</p>
+    </header>
+
+    {% if error %}
+    <div class="error" role="alert">{{ error }}</div>
+    {% endif %}
+
+    <form action="{{ url_for('join') }}" method="post" autocomplete="off">
+      <label for="ssid">
+        Network
+        {% if ssids %}
+        <select name="ssid" id="ssid" required>
+          <option value="" disabled selected>Pick your home WiFi</option>
+          {% for s in ssids %}
+          <option value="{{ s }}">{{ s }}</option>
+          {% endfor %}
+          <option value="__manual__">Other (type below)</option>
+        </select>
+        {% else %}
+        <input type="text" name="ssid" id="ssid" required
+               placeholder="WiFi network name" autocomplete="off">
+        {% endif %}
+      </label>
+
+      {% if ssids %}
+      <label for="ssid_manual" class="hidden" id="ssid-manual-label">
+        Network name
+        <input type="text" name="ssid_manual" id="ssid_manual"
+               placeholder="WiFi network name" autocomplete="off">
+      </label>
+      {% endif %}
+
+      <label for="password">
+        Password
+        <input type="password" name="password" id="password" required
+               minlength="8" placeholder="WiFi password" autocomplete="off">
+      </label>
+
+      <button type="submit">Join</button>
+    </form>
+
+    <footer>
+      <small>Connected to AP <code>{{ ssid }}</code></small>
+    </footer>
+  </main>
+
+  {% if ssids %}
+  <script>
+    const select = document.getElementById('ssid');
+    const manualLabel = document.getElementById('ssid-manual-label');
+    const manualInput = document.getElementById('ssid_manual');
+    select.addEventListener('change', () => {
+      const showManual = select.value === '__manual__';
+      manualLabel.classList.toggle('hidden', !showManual);
+      manualInput.required = showManual;
+    });
+    document.querySelector('form').addEventListener('submit', e => {
+      if (select.value === '__manual__') {
+        select.value = manualInput.value;
+      }
+    });
+  </script>
+  {% endif %}
+</body>
+</html>

--- a/pi/firstboot/templates/joining.html
+++ b/pi/firstboot/templates/joining.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>smart-vent — joining {{ ssid }}…</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <main>
+    <header>
+      <h1>smart-vent</h1>
+      <p>Joining <strong>{{ ssid }}</strong>…</p>
+    </header>
+
+    <ol>
+      <li>The hub is leaving its setup network.</li>
+      <li>You'll lose this page in a few seconds — that's expected.</li>
+      <li>Reconnect your phone to <strong>{{ ssid }}</strong>, then open the smart-vent app to add your vents.</li>
+    </ol>
+
+    <p class="muted">
+      If the hub doesn't show up after a couple of minutes, power-cycle it. The setup network will come back automatically.
+    </p>
+  </main>
+</body>
+</html>

--- a/pi/firstboot/wizard.py
+++ b/pi/firstboot/wizard.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""First-boot AP-mode WiFi onboarding for smart-vent.
+
+Run by smart-vent-firstboot.service as root. The wizard:
+
+  1. Brings up an AP on wlan0 named "smart-vent-setup-<short-eui>"
+     with WPA2, IP 192.168.4.1, DHCP 192.168.4.10-50.
+  2. Runs a small Flask app on :80 that scans visible SSIDs and
+     accepts the client's home WiFi credentials.
+  3. Tears down the AP, writes an NM connection, joins the home
+     network. On success writes /var/lib/smart-vent/.configured
+     and reboots — which puts smart-vent.service in charge.
+
+This is intentionally ~250 LOC of Python rather than something like
+comitup so that:
+
+  - The SSID and captive page are branded smart-vent rather than the
+    upstream's defaults — matches what's printed on the kit-card.
+  - We keep using NetworkManager (Bookworm default) rather than
+    swapping the whole network stack for an alternative.
+  - One systemd unit, one process; no shell-out maze.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+try:
+    from flask import Flask, redirect, render_template, request, url_for
+except ImportError:
+    sys.stderr.write(
+        "wizard.py needs python3-flask. "
+        "apt install python3-flask, or rerun install.sh.\n"
+    )
+    raise
+
+# ----------------------------------------------------------------- constants
+AP_INTERFACE = "wlan0"
+AP_IP = "192.168.4.1"
+AP_NETMASK = "24"
+DHCP_RANGE = "192.168.4.10,192.168.4.50,12h"
+NM_CON_NAME = "smart-vent-home"
+
+STATE_FLAG = Path("/var/lib/smart-vent/.configured")
+AP_PASSWORD_FILE = Path("/etc/smart-vent/ap-password")
+DEFAULT_AP_PASSWORD = "smart-vent-setup"
+
+RUN_DIR = Path("/run/smart-vent")
+HOSTAPD_CONF = RUN_DIR / "hostapd.conf"
+DNSMASQ_CONF = RUN_DIR / "dnsmasq.conf"
+DNSMASQ_LEASES = RUN_DIR / "dnsmasq.leases"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="firstboot: %(message)s",
+)
+log = logging.getLogger("firstboot")
+
+# Sub-processes we own; torn down on shutdown / on join success.
+_subprocs: list[subprocess.Popen] = []
+
+
+# ============================================================ helpers
+def short_eui() -> str:
+    """Last 4 hex chars of the wlan0 MAC, lowercase, no separators."""
+    mac = Path(f"/sys/class/net/{AP_INTERFACE}/address").read_text().strip()
+    return mac.replace(":", "").lower()[-4:]
+
+
+def ap_ssid() -> str:
+    return f"smart-vent-setup-{short_eui()}"
+
+
+def ap_password() -> str:
+    """Operator-overridable AP password; default is the printed one.
+
+    /etc/smart-vent/ap-password takes precedence so the provider can
+    bake a per-kit password into the SD image. Must be >= 8 chars
+    (WPA2 minimum); falls back to default otherwise.
+    """
+    if AP_PASSWORD_FILE.exists():
+        pw = AP_PASSWORD_FILE.read_text().strip()
+        if len(pw) >= 8:
+            return pw
+        log.warning(
+            "AP password in %s is too short (<8 chars); using default.",
+            AP_PASSWORD_FILE,
+        )
+    return DEFAULT_AP_PASSWORD
+
+
+def run(cmd: list[str], *, check: bool = True, **kw) -> subprocess.CompletedProcess:
+    log.info("$ %s", " ".join(cmd))
+    return subprocess.run(cmd, check=check, text=True, **kw)
+
+
+# ============================================================ AP bring-up
+def write_hostapd_conf(ssid: str, password: str) -> None:
+    HOSTAPD_CONF.write_text(textwrap.dedent(f"""\
+        interface={AP_INTERFACE}
+        driver=nl80211
+        ssid={ssid}
+        hw_mode=g
+        channel=6
+        auth_algs=1
+        wpa=2
+        wpa_passphrase={password}
+        wpa_key_mgmt=WPA-PSK
+        wpa_pairwise=TKIP
+        rsn_pairwise=CCMP
+    """))
+
+
+def write_dnsmasq_conf() -> None:
+    DNSMASQ_CONF.write_text(textwrap.dedent(f"""\
+        interface={AP_INTERFACE}
+        bind-interfaces
+        dhcp-range={DHCP_RANGE}
+        dhcp-leasefile={DNSMASQ_LEASES}
+        # Captive-portal style: resolve everything to ourselves so the
+        # client phone's connectivity probe sees the wizard page.
+        address=/#/{AP_IP}
+        no-resolv
+        log-queries
+        log-dhcp
+    """))
+
+
+def bring_up_ap(ssid: str, password: str) -> None:
+    log.info("Bringing up AP %r on %s ...", ssid, AP_INTERFACE)
+    RUN_DIR.mkdir(parents=True, exist_ok=True)
+
+    # NM must not fight us for wlan0 while the AP is up.
+    run(["nmcli", "device", "set", AP_INTERFACE, "managed", "no"], check=False)
+
+    # Reset interface to a known state, give it the AP IP.
+    run(["ip", "addr", "flush", "dev", AP_INTERFACE], check=False)
+    run(["ip", "link", "set", AP_INTERFACE, "up"], check=False)
+    run(["ip", "addr", "add", f"{AP_IP}/{AP_NETMASK}", "dev", AP_INTERFACE])
+
+    write_hostapd_conf(ssid, password)
+    write_dnsmasq_conf()
+
+    # Stop systemd's copies if they happen to be running; we manage
+    # both processes directly.
+    for unit in ("hostapd.service", "dnsmasq.service"):
+        run(["systemctl", "stop", unit], check=False)
+
+    _subprocs.append(subprocess.Popen(["hostapd", str(HOSTAPD_CONF)]))
+    _subprocs.append(subprocess.Popen(
+        ["dnsmasq", "--no-daemon", "--conf-file=" + str(DNSMASQ_CONF)],
+    ))
+    log.info("AP %r is up at http://%s/", ssid, AP_IP)
+
+
+def tear_down_ap() -> None:
+    log.info("Tearing down AP processes...")
+    for p in _subprocs:
+        try:
+            p.terminate()
+        except Exception:
+            pass
+    for p in _subprocs:
+        try:
+            p.wait(timeout=5)
+        except Exception:
+            try:
+                p.kill()
+            except Exception:
+                pass
+    _subprocs.clear()
+    run(["ip", "addr", "flush", "dev", AP_INTERFACE], check=False)
+    run(["nmcli", "device", "set", AP_INTERFACE, "managed", "yes"], check=False)
+
+
+# ============================================================ scan + join
+def scan_ssids() -> list[str]:
+    """Return visible non-empty SSIDs, deduplicated, signal-sorted."""
+    # nmcli requires NM to manage the interface for scanning, but we
+    # set it unmanaged above. Easiest workaround: ask nmcli to rescan
+    # while temporarily reclaiming the iface? Simpler: use `iw scan`
+    # which talks to nl80211 directly.
+    result = run(
+        ["iw", "dev", AP_INTERFACE, "scan", "ap-force"],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        log.warning("iw scan failed (rc=%s); SSID list will be empty.", result.returncode)
+        return []
+
+    ssids = []
+    seen = set()
+    for line in result.stdout.splitlines():
+        m = re.match(r"\s*SSID: (.+)", line)
+        if not m:
+            continue
+        ssid = m.group(1).strip()
+        if not ssid or ssid in seen:
+            continue
+        seen.add(ssid)
+        ssids.append(ssid)
+    return ssids
+
+
+def join_home_wifi(ssid: str, password: str) -> bool:
+    """Switch wlan0 to client mode and try to join the home network."""
+    log.info("Tearing down AP, switching to client mode for SSID %r ...", ssid)
+    tear_down_ap()
+
+    # Remove any prior smart-vent-home connection so re-runs don't pile up.
+    run(["nmcli", "connection", "delete", NM_CON_NAME], check=False)
+    add = run(
+        [
+            "nmcli", "connection", "add",
+            "type", "wifi",
+            "ifname", AP_INTERFACE,
+            "con-name", NM_CON_NAME,
+            "ssid", ssid,
+            "wifi-sec.key-mgmt", "wpa-psk",
+            "wifi-sec.psk", password,
+            "connection.autoconnect", "yes",
+        ],
+        check=False,
+    )
+    if add.returncode != 0:
+        return False
+
+    up = run(["nmcli", "connection", "up", NM_CON_NAME], check=False, capture_output=True)
+    if up.returncode == 0:
+        log.info("Joined %r.", ssid)
+        return True
+
+    log.warning("nmcli connection up failed: %s", up.stderr.strip())
+    # Clean up the bad connection so we don't retry it forever.
+    run(["nmcli", "connection", "delete", NM_CON_NAME], check=False)
+    return False
+
+
+# ============================================================ flask app
+app = Flask(
+    "smart-vent-firstboot",
+    template_folder=str(Path(__file__).resolve().parent / "templates"),
+    static_folder=str(Path(__file__).resolve().parent / "static"),
+)
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template(
+        "index.html",
+        ssid=ap_ssid(),
+        ssids=scan_ssids(),
+    )
+
+
+# Captive-portal hint endpoints: phones probe these and follow the redirect.
+@app.route("/generate_204")
+@app.route("/hotspot-detect.html")
+@app.route("/connecttest.txt")
+@app.route("/ncsi.txt")
+def captive_probe():
+    return redirect(url_for("index"), code=302)
+
+
+@app.route("/join", methods=["POST"])
+def join():
+    ssid = (request.form.get("ssid") or "").strip()
+    password = request.form.get("password") or ""
+
+    if not ssid:
+        return render_template("index.html", ssid=ap_ssid(), ssids=scan_ssids(),
+                               error="Please pick a network."), 400
+    if len(password) < 8:
+        return render_template("index.html", ssid=ap_ssid(), ssids=scan_ssids(),
+                               error="WPA2 passwords need at least 8 characters."), 400
+
+    # Render the joining page first so the user sees feedback before we
+    # drop the AP from under them.
+    page = render_template("joining.html", ssid=ssid)
+
+    def _finish():
+        # Give the response time to flush back over the AP before we
+        # tear it down.
+        time.sleep(2)
+        if join_home_wifi(ssid, password):
+            STATE_FLAG.parent.mkdir(parents=True, exist_ok=True)
+            STATE_FLAG.touch()
+            log.info("Onboarding succeeded; rebooting.")
+            run(["systemctl", "reboot"], check=False)
+        else:
+            log.warning("Onboarding failed; bringing the AP back up.")
+            bring_up_ap(ap_ssid(), ap_password())
+
+    # Schedule _finish in a child thread so Flask returns the HTML first.
+    import threading
+    threading.Thread(target=_finish, daemon=True).start()
+    return page
+
+
+# ============================================================ main
+def _shutdown(*_):
+    tear_down_ap()
+    sys.exit(0)
+
+
+def main() -> int:
+    if STATE_FLAG.exists():
+        log.info(".configured already exists; nothing to do.")
+        return 0
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    bring_up_ap(ap_ssid(), ap_password())
+    log.info(
+        "Wizard listening on %s:80 (SSID %r, password %r).",
+        AP_IP, ap_ssid(), ap_password(),
+    )
+    app.run(host="0.0.0.0", port=80, debug=False, use_reloader=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 # --------------------------------------------------------------- defaults
 REPO_URL="https://github.com/EtaCassiopeia/smart-vent"
 INSTALL_DIR="/opt/smart-vent"
+DATA_DIR="/opt/smart-vent/data"
 STATE_DIR="/var/lib/smart-vent"
 SYSTEMD_DIR="/etc/systemd/system"
 
@@ -120,15 +121,52 @@ fetch_source() {
 deploy_files() {
   say "Deploying to $INSTALL_DIR ..."
   mkdir -p "$INSTALL_DIR" "$STATE_DIR"
+
+  # Container data dirs live under $DATA_DIR so the operator can back
+  # them up with tar and edit HA's config in place. Created with
+  # restrictive permissions; HA / matter-server / OTBR run as root
+  # inside their containers, so the host-side ownership doesn't
+  # block them.
+  mkdir -p "$DATA_DIR/otbr" "$DATA_DIR/matter-server" "$DATA_DIR/homeassistant"
+  chmod 700 "$DATA_DIR/matter-server"   # has Matter fabric credentials
+
   # Copy the pi/ tree (and only the pi/ tree) under /opt/smart-vent/pi/.
-  # We use rsync so an upgrade-in-place doesn't drop file modes the
-  # systemd units depend on.
-  rsync -a --delete "$SRC_DIR/pi/" "$INSTALL_DIR/pi/"
+  # rsync so an upgrade-in-place doesn't drop file modes the systemd
+  # units depend on, and so we don't blow away $DATA_DIR (--exclude).
+  rsync -a --delete --exclude '/data' "$SRC_DIR/pi/" "$INSTALL_DIR/pi/"
 
   # Seed .env from .env.example if no operator-edited .env yet.
   if [[ ! -f "$INSTALL_DIR/pi/.env" ]]; then
     cp "$INSTALL_DIR/pi/.env.example" "$INSTALL_DIR/pi/.env"
   fi
+}
+
+# --------------------------------------------- seed Home Assistant config
+# Seeds /opt/smart-vent/data/homeassistant/ with:
+#   - configuration.yaml from pi/config/homeassistant/
+#   - scripts.yaml, automations.yaml, helpers/, dashboards/ from the
+#     repo's top-level homeassistant/ templates (same content used by
+#     people who manually copy them into a stock HA install)
+# Never overwrites an existing configuration.yaml — operator edits win.
+seed_homeassistant_config() {
+  local target="$DATA_DIR/homeassistant"
+  if [[ -f "$target/configuration.yaml" ]]; then
+    say "HA config exists at $target/configuration.yaml; leaving it alone."
+    return
+  fi
+
+  say "Seeding HA bootstrap config into $target ..."
+  install -m 0644 "$SRC_DIR/pi/config/homeassistant/configuration.yaml" \
+    "$target/configuration.yaml"
+
+  # Copy the template files in (scripts.yaml, automations.yaml, etc.).
+  mkdir -p "$target/helpers" "$target/dashboards"
+  install -m 0644 "$SRC_DIR/homeassistant/scripts.yaml"     "$target/scripts.yaml"
+  install -m 0644 "$SRC_DIR/homeassistant/automations.yaml" "$target/automations.yaml"
+  install -m 0644 "$SRC_DIR/homeassistant/helpers/schedule_helpers.yaml" \
+    "$target/helpers/schedule_helpers.yaml"
+  install -m 0644 "$SRC_DIR/homeassistant/dashboards/vents.yaml" \
+    "$target/dashboards/vents.yaml"
 }
 
 # ----------------------------------------------------- systemd units
@@ -182,6 +220,7 @@ preflight
 install_packages
 fetch_source
 deploy_files
+seed_homeassistant_config
 install_units
 prepull_images
 print_summary

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# install.sh — idempotent installer for the smart-vent Pi runtime.
+#
+# Run paths:
+#
+#   # From a fresh Pi over the network:
+#   curl -sSL https://raw.githubusercontent.com/EtaCassiopeia/smart-vent/main/pi/install.sh \
+#       | sudo bash
+#
+#   # From a local checkout (developer flow, also what the SD image builder uses):
+#   sudo SMART_VENT_SRC=$(pwd) bash pi/install.sh
+#
+# Optional args:
+#   --tag <ref>         git ref to clone (default: latest hub-v* tag)
+#   --skip-wizard       Mark .configured immediately, skip first-boot WiFi
+#                       onboarding. For SD images that ship with WiFi
+#                       creds pre-seeded, or for wired-Ethernet installs.
+#   --from-source DIR   Same as setting SMART_VENT_SRC.
+#
+# Re-running is safe — every step is idempotent.
+
+set -euo pipefail
+
+# --------------------------------------------------------------- defaults
+REPO_URL="https://github.com/EtaCassiopeia/smart-vent"
+INSTALL_DIR="/opt/smart-vent"
+STATE_DIR="/var/lib/smart-vent"
+SYSTEMD_DIR="/etc/systemd/system"
+
+TAG=""
+SKIP_WIZARD=0
+SRC_DIR="${SMART_VENT_SRC:-}"
+
+# ------------------------------------------------------------- arg parse
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="$2"; shift 2 ;;
+    --skip-wizard) SKIP_WIZARD=1; shift ;;
+    --from-source) SRC_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^set/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "install.sh: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ------------------------------------------------------------- helpers
+say()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+  [[ $EUID -eq 0 ]] || die "must run as root (try: sudo bash $0)"
+}
+
+preflight() {
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}${ID_LIKE:-}" in
+      *raspbian*|*debian*|*ubuntu*) ;;
+      *)
+        warn "OS is '${PRETTY_NAME:-unknown}'. install.sh targets Raspberry Pi OS / Debian. Continuing, but you may need to adjust by hand."
+        ;;
+    esac
+  fi
+
+  case "$(uname -m)" in
+    aarch64|arm*|x86_64) ;;
+    *)
+      warn "uname -m reports '$(uname -m)'. Docker images target arm64/armhf/amd64; YMMV."
+      ;;
+  esac
+}
+
+# ----------------------------------------------------------- apt packages
+install_packages() {
+  say "Installing system packages (docker, compose plugin, AP-mode wizard deps)..."
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl git \
+    docker.io docker-compose-plugin \
+    hostapd dnsmasq \
+    python3 python3-flask \
+    network-manager
+  systemctl enable --now docker.service >/dev/null
+}
+
+# ----------------------------------------------------- get source on disk
+fetch_source() {
+  if [[ -n "$SRC_DIR" ]]; then
+    [[ -f "$SRC_DIR/pi/docker-compose.yaml" ]] || die "SMART_VENT_SRC=$SRC_DIR does not look like a smart-vent checkout"
+    say "Using local source: $SRC_DIR"
+    return
+  fi
+
+  # Resolve tag if not pinned.
+  if [[ -z "$TAG" ]]; then
+    TAG=$(curl -sSL "https://api.github.com/repos/EtaCassiopeia/smart-vent/tags?per_page=100" \
+      | grep -oE '"name":\s*"hub-v[^"]+"' \
+      | head -n1 \
+      | sed -E 's/.*"(hub-v[^"]+)".*/\1/' || true)
+    if [[ -z "$TAG" ]]; then
+      warn "No hub-v* tag published yet; falling back to main."
+      TAG="main"
+    fi
+  fi
+
+  SRC_DIR=$(mktemp -d -t smart-vent-XXXXXX)
+  say "Cloning $REPO_URL @ $TAG into $SRC_DIR..."
+  git clone --depth 1 --branch "$TAG" "$REPO_URL" "$SRC_DIR"
+}
+
+# ----------------------------------------------------- lay down /opt + state
+deploy_files() {
+  say "Deploying to $INSTALL_DIR ..."
+  mkdir -p "$INSTALL_DIR" "$STATE_DIR"
+  # Copy the pi/ tree (and only the pi/ tree) under /opt/smart-vent/pi/.
+  # We use rsync so an upgrade-in-place doesn't drop file modes the
+  # systemd units depend on.
+  rsync -a --delete "$SRC_DIR/pi/" "$INSTALL_DIR/pi/"
+
+  # Seed .env from .env.example if no operator-edited .env yet.
+  if [[ ! -f "$INSTALL_DIR/pi/.env" ]]; then
+    cp "$INSTALL_DIR/pi/.env.example" "$INSTALL_DIR/pi/.env"
+  fi
+}
+
+# ----------------------------------------------------- systemd units
+install_units() {
+  say "Installing systemd units..."
+  install -m 0644 "$INSTALL_DIR/pi/systemd/smart-vent.service" "$SYSTEMD_DIR/smart-vent.service"
+  install -m 0644 "$INSTALL_DIR/pi/systemd/smart-vent-firstboot.service" "$SYSTEMD_DIR/smart-vent-firstboot.service"
+  systemctl daemon-reload
+  systemctl enable smart-vent.service >/dev/null
+
+  if [[ "$SKIP_WIZARD" -eq 1 ]]; then
+    say "Skipping first-boot wizard (--skip-wizard); marking .configured."
+    touch "$STATE_DIR/.configured"
+    systemctl disable smart-vent-firstboot.service >/dev/null 2>&1 || true
+  else
+    systemctl enable smart-vent-firstboot.service >/dev/null
+  fi
+}
+
+# ----------------------------------------------------- pre-pull images
+prepull_images() {
+  say "Pre-pulling docker images (so first boot doesn't need internet)..."
+  # Compose v2 plugin has `pull`.
+  (cd "$INSTALL_DIR/pi" && docker compose pull --quiet) || warn "image pre-pull failed; will retry at first boot"
+}
+
+# ----------------------------------------------------- summary
+print_summary() {
+  echo
+  say "smart-vent runtime installed at $INSTALL_DIR/pi"
+  echo "    compose:   $INSTALL_DIR/pi/docker-compose.yaml"
+  echo "    state:     $STATE_DIR (.configured = onboarding flag)"
+  echo "    units:     $SYSTEMD_DIR/smart-vent{,-firstboot}.service"
+
+  if [[ "$SKIP_WIZARD" -eq 1 ]]; then
+    echo
+    echo "    First-boot wizard SKIPPED. Reboot or run:"
+    echo "        sudo systemctl start smart-vent.service"
+  else
+    echo
+    echo "    On next boot the Pi will publish an AP named"
+    echo "        smart-vent-setup-<short-eui>"
+    echo "    Connect with your phone and follow the captive page to"
+    echo "    enter your home WiFi credentials."
+  fi
+}
+
+# ============================================================= main
+require_root
+preflight
+install_packages
+fetch_source
+deploy_files
+install_units
+prepull_images
+print_summary

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -10,12 +10,18 @@
 #   # From a local checkout (developer flow, also what the SD image builder uses):
 #   sudo SMART_VENT_SRC=$(pwd) bash pi/install.sh
 #
+#   # Preview without changing anything (no sudo required):
+#   SMART_VENT_SRC=$(pwd) bash pi/install.sh --dry-run
+#
 # Optional args:
 #   --tag <ref>         git ref to clone (default: latest hub-v* tag)
 #   --skip-wizard       Mark .configured immediately, skip first-boot WiFi
 #                       onboarding. For SD images that ship with WiFi
 #                       creds pre-seeded, or for wired-Ethernet installs.
 #   --from-source DIR   Same as setting SMART_VENT_SRC.
+#   --dry-run           Print every action without executing it. Skips
+#                       the root check; safe to preview on a running
+#                       system.
 #
 # Re-running is safe — every step is idempotent.
 
@@ -31,6 +37,7 @@ SYSTEMD_DIR="/etc/systemd/system"
 TAG=""
 SKIP_WIZARD=0
 SRC_DIR="${SMART_VENT_SRC:-}"
+DRY_RUN=0
 
 # ------------------------------------------------------------- arg parse
 while [[ $# -gt 0 ]]; do
@@ -38,6 +45,7 @@ while [[ $# -gt 0 ]]; do
     --tag) TAG="$2"; shift 2 ;;
     --skip-wizard) SKIP_WIZARD=1; shift ;;
     --from-source) SRC_DIR="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
     -h|--help)
       sed -n '2,/^set/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
       exit 0
@@ -54,7 +62,31 @@ say()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
 
+# run: execute a command, or in dry-run mode print what would be run.
+# Use this for every state-mutating action — apt, mkdir, install, cp,
+# rsync, systemctl, docker, git clone.
+run() {
+  if [[ $DRY_RUN -eq 1 ]]; then
+    printf '  \033[2m[dry-run]\033[0m %s\n' "$*"
+    return 0
+  fi
+  "$@"
+}
+
+# run_sh: same, for compound shell snippets (heredoc, pipes, cd …).
+run_sh() {
+  if [[ $DRY_RUN -eq 1 ]]; then
+    printf '  \033[2m[dry-run]\033[0m sh -c %q\n' "$*"
+    return 0
+  fi
+  bash -c "$*"
+}
+
 require_root() {
+  if [[ $DRY_RUN -eq 1 ]]; then
+    [[ $EUID -eq 0 ]] || warn "running as non-root in --dry-run; real install needs sudo."
+    return
+  fi
   [[ $EUID -eq 0 ]] || die "must run as root (try: sudo bash $0)"
 }
 
@@ -81,15 +113,17 @@ preflight() {
 # ----------------------------------------------------------- apt packages
 install_packages() {
   say "Installing system packages (docker, compose plugin, AP-mode wizard deps)..."
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get update -qq
-  apt-get install -y --no-install-recommends \
-    ca-certificates curl git \
+  if [[ $DRY_RUN -eq 0 ]]; then
+    export DEBIAN_FRONTEND=noninteractive
+  fi
+  run apt-get update -qq
+  run apt-get install -y --no-install-recommends \
+    ca-certificates curl git rsync \
     docker.io docker-compose-plugin \
     hostapd dnsmasq \
     python3 python3-flask \
     network-manager
-  systemctl enable --now docker.service >/dev/null
+  run systemctl enable --now docker.service
 }
 
 # ----------------------------------------------------- get source on disk
@@ -112,6 +146,11 @@ fetch_source() {
     fi
   fi
 
+  if [[ $DRY_RUN -eq 1 ]]; then
+    SRC_DIR="<would-clone-to-mktemp>"
+    say "Would clone $REPO_URL @ $TAG"
+    return
+  fi
   SRC_DIR=$(mktemp -d -t smart-vent-XXXXXX)
   say "Cloning $REPO_URL @ $TAG into $SRC_DIR..."
   git clone --depth 1 --branch "$TAG" "$REPO_URL" "$SRC_DIR"
@@ -120,24 +159,24 @@ fetch_source() {
 # ----------------------------------------------------- lay down /opt + state
 deploy_files() {
   say "Deploying to $INSTALL_DIR ..."
-  mkdir -p "$INSTALL_DIR" "$STATE_DIR"
+  run mkdir -p "$INSTALL_DIR" "$STATE_DIR"
 
   # Container data dirs live under $DATA_DIR so the operator can back
   # them up with tar and edit HA's config in place. Created with
   # restrictive permissions; HA / matter-server / OTBR run as root
   # inside their containers, so the host-side ownership doesn't
   # block them.
-  mkdir -p "$DATA_DIR/otbr" "$DATA_DIR/matter-server" "$DATA_DIR/homeassistant"
-  chmod 700 "$DATA_DIR/matter-server"   # has Matter fabric credentials
+  run mkdir -p "$DATA_DIR/otbr" "$DATA_DIR/matter-server" "$DATA_DIR/homeassistant"
+  run chmod 700 "$DATA_DIR/matter-server"   # has Matter fabric credentials
 
   # Copy the pi/ tree (and only the pi/ tree) under /opt/smart-vent/pi/.
   # rsync so an upgrade-in-place doesn't drop file modes the systemd
   # units depend on, and so we don't blow away $DATA_DIR (--exclude).
-  rsync -a --delete --exclude '/data' "$SRC_DIR/pi/" "$INSTALL_DIR/pi/"
+  run rsync -a --delete --exclude '/data' "$SRC_DIR/pi/" "$INSTALL_DIR/pi/"
 
   # Seed .env from .env.example if no operator-edited .env yet.
   if [[ ! -f "$INSTALL_DIR/pi/.env" ]]; then
-    cp "$INSTALL_DIR/pi/.env.example" "$INSTALL_DIR/pi/.env"
+    run cp "$INSTALL_DIR/pi/.env.example" "$INSTALL_DIR/pi/.env"
   fi
 }
 
@@ -156,33 +195,37 @@ seed_homeassistant_config() {
   fi
 
   say "Seeding HA bootstrap config into $target ..."
-  install -m 0644 "$SRC_DIR/pi/config/homeassistant/configuration.yaml" \
+  run install -m 0644 "$SRC_DIR/pi/config/homeassistant/configuration.yaml" \
     "$target/configuration.yaml"
 
   # Copy the template files in (scripts.yaml, automations.yaml, etc.).
-  mkdir -p "$target/helpers" "$target/dashboards"
-  install -m 0644 "$SRC_DIR/homeassistant/scripts.yaml"     "$target/scripts.yaml"
-  install -m 0644 "$SRC_DIR/homeassistant/automations.yaml" "$target/automations.yaml"
-  install -m 0644 "$SRC_DIR/homeassistant/helpers/schedule_helpers.yaml" \
+  run mkdir -p "$target/helpers" "$target/dashboards"
+  run install -m 0644 "$SRC_DIR/homeassistant/scripts.yaml"     "$target/scripts.yaml"
+  run install -m 0644 "$SRC_DIR/homeassistant/automations.yaml" "$target/automations.yaml"
+  run install -m 0644 "$SRC_DIR/homeassistant/helpers/schedule_helpers.yaml" \
     "$target/helpers/schedule_helpers.yaml"
-  install -m 0644 "$SRC_DIR/homeassistant/dashboards/vents.yaml" \
+  run install -m 0644 "$SRC_DIR/homeassistant/dashboards/vents.yaml" \
     "$target/dashboards/vents.yaml"
 }
 
 # ----------------------------------------------------- systemd units
 install_units() {
   say "Installing systemd units..."
-  install -m 0644 "$INSTALL_DIR/pi/systemd/smart-vent.service" "$SYSTEMD_DIR/smart-vent.service"
-  install -m 0644 "$INSTALL_DIR/pi/systemd/smart-vent-firstboot.service" "$SYSTEMD_DIR/smart-vent-firstboot.service"
-  systemctl daemon-reload
-  systemctl enable smart-vent.service >/dev/null
+  run install -m 0644 "$INSTALL_DIR/pi/systemd/smart-vent.service" "$SYSTEMD_DIR/smart-vent.service"
+  run install -m 0644 "$INSTALL_DIR/pi/systemd/smart-vent-firstboot.service" "$SYSTEMD_DIR/smart-vent-firstboot.service"
+  run systemctl daemon-reload
+  run systemctl enable smart-vent.service
 
   if [[ "$SKIP_WIZARD" -eq 1 ]]; then
     say "Skipping first-boot wizard (--skip-wizard); marking .configured."
-    touch "$STATE_DIR/.configured"
-    systemctl disable smart-vent-firstboot.service >/dev/null 2>&1 || true
+    run touch "$STATE_DIR/.configured"
+    if [[ $DRY_RUN -eq 1 ]]; then
+      printf '  \033[2m[dry-run]\033[0m systemctl disable smart-vent-firstboot.service\n'
+    else
+      systemctl disable smart-vent-firstboot.service >/dev/null 2>&1 || true
+    fi
   else
-    systemctl enable smart-vent-firstboot.service >/dev/null
+    run systemctl enable smart-vent-firstboot.service
   fi
 }
 
@@ -190,12 +233,21 @@ install_units() {
 prepull_images() {
   say "Pre-pulling docker images (so first boot doesn't need internet)..."
   # Compose v2 plugin has `pull`.
+  if [[ $DRY_RUN -eq 1 ]]; then
+    printf '  \033[2m[dry-run]\033[0m (cd %s && docker compose pull --quiet)\n' "$INSTALL_DIR/pi"
+    return
+  fi
   (cd "$INSTALL_DIR/pi" && docker compose pull --quiet) || warn "image pre-pull failed; will retry at first boot"
 }
 
 # ----------------------------------------------------- summary
 print_summary() {
   echo
+  if [[ $DRY_RUN -eq 1 ]]; then
+    say "DRY RUN complete — nothing was changed."
+    echo "    Run again without --dry-run (as root) to apply."
+    return
+  fi
   say "smart-vent runtime installed at $INSTALL_DIR/pi"
   echo "    compose:   $INSTALL_DIR/pi/docker-compose.yaml"
   echo "    state:     $STATE_DIR (.configured = onboarding flag)"

--- a/pi/systemd/smart-vent-firstboot.service
+++ b/pi/systemd/smart-vent-firstboot.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Smart Vent first-boot WiFi onboarding (AP-mode wizard)
+Documentation=https://github.com/EtaCassiopeia/smart-vent
+# Only run when the wizard hasn't already succeeded. The wizard writes
+# /var/lib/smart-vent/.configured on a successful WiFi join and reboots.
+ConditionPathExists=!/var/lib/smart-vent/.configured
+# We bring up the AP ourselves; don't wait for network-online (it would
+# never fire on a brand-new Pi).
+After=network-pre.target NetworkManager.service
+Wants=NetworkManager.service
+# Block the main service so we don't bring docker up on an offline Pi.
+Before=smart-vent.service
+# On a wizard crash, retry a handful of times before giving up so the
+# Pi doesn't get stuck rebooting. The wizard itself is idempotent.
+StartLimitIntervalSec=600
+StartLimitBurst=6
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/smart-vent/pi/firstboot
+# The wizard owns hostapd, dnsmasq, and nmcli for the duration of
+# onboarding. Needs root for those, so no User= or DynamicUser=.
+ExecStart=/usr/bin/env python3 /opt/smart-vent/pi/firstboot/wizard.py
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/pi/systemd/smart-vent.service
+++ b/pi/systemd/smart-vent.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Smart Vent hub (OTBR + matter-server + Home Assistant)
+Documentation=https://github.com/EtaCassiopeia/smart-vent
+# We need docker, and we need WiFi to be up — the latter is what
+# smart-vent-firstboot.service guarantees on a fresh Pi, so this unit
+# also waits for the first-boot wizard if it's installed.
+Requires=docker.service
+After=docker.service network-online.target smart-vent-firstboot.service
+# Don't even try if WiFi/Ethernet failed to come up.
+Wants=network-online.target
+# Skip if the first-boot wizard hasn't completed (no .configured flag
+# yet) — this prevents the compose from starting on a Pi that isn't
+# on the LAN, which would just churn restarts.
+ConditionPathExists=/var/lib/smart-vent/.configured
+# A failing compose up is almost always a missing dongle or a pulled
+# image regression. Don't loop forever; surface the journal.
+StartLimitIntervalSec=300
+StartLimitBurst=4
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/smart-vent/pi
+# Source the operator-edited .env (BACKBONE_INTERFACE, future knobs).
+EnvironmentFile=-/opt/smart-vent/pi/.env
+ExecStart=/usr/bin/docker compose --file /opt/smart-vent/pi/docker-compose.yaml up --detach --remove-orphans
+ExecStop=/usr/bin/docker compose --file /opt/smart-vent/pi/docker-compose.yaml down
+Restart=on-failure
+RestartSec=15s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Workstream B of the deployment plan: everything that needs to be **on** a client's Pi. Single feature branch built up over 6 commits, each a reviewable step.

| Commit | What it adds |
|---|---|
| `02c689d` | `pi/docker-compose.yaml` — replaces the three hand-typed `docker run`s in runbook §3. Pinned image tags. `BACKBONE_INTERFACE` from `.env`. Deliberately omits the stale `devices.db` bind mount the legacy hub left behind. |
| `bd08deb` | `pi/systemd/*` — `smart-vent.service` (oneshot, `docker compose up -d`, gated on `.configured`) + `smart-vent-firstboot.service` (the wizard, ordered `Before=smart-vent.service`). `systemd-analyze verify` clean. |
| `acc116c` | `pi/install.sh` — idempotent installer. Two source paths converge at the same `/opt/smart-vent/` layout: curl-from-GitHub at the latest `hub-v*` tag, or local checkout via `SMART_VENT_SRC=` / `--from-source` (used by the SD-image bake in PR C). `--skip-wizard` for wired/pre-seeded installs. |
| `7f37804` | `pi/firstboot/` — Flask + hostapd + dnsmasq + nmcli wizard. Branded SSID `smart-vent-setup-<short-eui>`, WPA2, captive-portal probes 302 to the wizard page. On success: writes `.configured` and reboots. ~250 LOC of one Python file; chose custom over comitup for branding + NetworkManager compat (rationale in `pi/firstboot/README.md`). |
| `eba6876` | `pi/config/homeassistant/configuration.yaml` + bind mounts. Compose data dirs move from docker-managed volumes to `/opt/smart-vent/data/{otbr,matter-server,homeassistant}/` so operators can back up with tar and edit HA config in place. `install.sh` seeds `data/homeassistant/` with the bootstrap `configuration.yaml` plus the `scripts.yaml` / `automations.yaml` / schedule helpers / Vents dashboard from PR #31's `homeassistant/` templates. |
| `908944c` | `pi/install.sh --dry-run` — threads a `run()` helper through every state-mutating action (apt, systemctl, mkdir, install, cp, rsync, docker, git clone, touch) so operators can preview the exact command sequence without executing it. Relaxes the root check to a warning in dry-run, so it's safe to run from a user shell against the live repo. |

## Data layout on the Pi after install

```
/opt/smart-vent/
  pi/                    # everything from this directory, rsync'd here
  data/                  # container state, bind-mounted into the services
    otbr/                # Thread dataset + Thread network state
    matter-server/       # Fabric credentials + matter-server storage (chmod 700)
    homeassistant/       # HA /config — operator can edit in place

/var/lib/smart-vent/
  .configured            # set by the wizard on first successful WiFi join

/etc/systemd/system/
  smart-vent.service
  smart-vent-firstboot.service
```

## First-boot flow

1. Fresh Pi boots → `smart-vent-firstboot.service` runs (no `.configured` yet).
2. Wizard brings up AP `smart-vent-setup-XXXX`, dnsmasq resolves everything to itself so captive-portal probes hit the wizard.
3. Client phone connects, fills the SSID + password form.
4. Wizard tears AP down → `nmcli connection add wifi …` → `connection up` → writes `.configured` → reboots.
5. After reboot: firstboot is skipped (condition fails), `smart-vent.service` runs `docker compose up -d` → HA, matter-server, and OTBR come online.

## Out of scope (separate workstreams)

- **PR C** — SD card image bake (`pi-gen` + QEMU producing `smart-vent-hub-<ver>-rpi4.img.xz`). Will re-use `install.sh` against a chroot.
- The `hub-v0.1.0` release tag — separate once docs/runbook are updated to point at the new install path.
- Per-device unique Matter passcodes — v2 firmware concern, deferred per plan.

## Test plan

- [x] `bash -n` clean on `install.sh`; `--help` text accessible.
- [x] `systemd-analyze verify` clean on both unit files.
- [x] `wizard.py` parses (AST check) and Flask app constructs.
- [x] Compose YAML lint clean (`yaml.safe_load` parses, 3 services, bind-mount paths correct).
- [x] `install.sh --dry-run` walks every state-mutating action without executing — verified against the live repo as a non-root user (`SMART_VENT_SRC=$(pwd) bash pi/install.sh --dry-run`).
- [ ] **Operator-driven smoke on a clean Pi:**
  - `sudo SMART_VENT_SRC=$(pwd) bash pi/install.sh --skip-wizard` should populate `/opt/smart-vent/` + `data/` and pre-pull images.
  - `sudo systemctl daemon-reload && sudo systemctl start smart-vent.service` should bring the three containers up; `curl localhost:8123` returns 200.
  - HA's UI shows the seeded Vents dashboard (Sidebar → Vents) with the area/floor/whole-house buttons.
- [ ] **Wizard smoke on a clean Pi:** unset `.configured`, reboot, confirm `smart-vent-setup-XXXX` SSID appears, captive page renders, form POST joins the home WiFi.

> ⚠️ The hardware smoke needs a **clean Pi or a spare SD card** — running the real `install.sh` on the current dev Pi would conflict with its already-named docker containers (`otbr` / `matter-server` / `homeassistant`) and the first-boot wizard would seize `wlan0` on the next reboot. Use `--dry-run` from this Pi to preview safely.
