### PR TITLE
Install ip6_tables + ip6table_filter for OTBR routing

### DIFF
--- a/pi/config/modules-load.d/otbr.conf
+++ b/pi/config/modules-load.d/otbr.conf
@@ -1,0 +1,6 @@
+# OpenThread Border Router needs the IPv6 netfilter modules to route
+# Thread <-> backbone (wlan0/eth0). Without them OTBR comes up but vents
+# on Thread can't reach matter-server — symptom is "device joins mesh
+# but HA shows it Unavailable forever". See docs/runbook.md §2.1.
+ip6_tables
+ip6table_filter

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -178,6 +178,14 @@ deploy_files() {
   if [[ ! -f "$INSTALL_DIR/pi/.env" ]]; then
     run cp "$INSTALL_DIR/pi/.env.example" "$INSTALL_DIR/pi/.env"
   fi
+
+  # OTBR needs ip6_tables + ip6table_filter loaded to route IPv6
+  # Thread <-> backbone. Persist via modules-load.d so the modules
+  # come up on every boot. Also modprobe them now so the first
+  # docker compose up after install works without a reboot.
+  run install -m 0644 "$INSTALL_DIR/pi/config/modules-load.d/otbr.conf" /etc/modules-load.d/otbr.conf
+  run modprobe ip6_tables
+  run modprobe ip6table_filter
 }
 
 # --------------------------------------------- seed Home Assistant config

--- a/sd-image/stage-smart-vent/02-copy-runtime/01-run.sh
+++ b/sd-image/stage-smart-vent/02-copy-runtime/01-run.sh
@@ -35,6 +35,13 @@ fi
 install -m 0644 "${SRC}/pi/systemd/smart-vent.service"           "${SYSTEMD_DIR}/smart-vent.service"
 install -m 0644 "${SRC}/pi/systemd/smart-vent-firstboot.service" "${SYSTEMD_DIR}/smart-vent-firstboot.service"
 
+# OTBR needs ip6_tables + ip6table_filter loaded to route IPv6
+# Thread <-> backbone. Persist via modules-load.d so kernel loads
+# them on every boot of the baked image.
+mkdir -p "${ROOTFS_DIR}/etc/modules-load.d"
+install -m 0644 "${SRC}/pi/config/modules-load.d/otbr.conf" \
+    "${ROOTFS_DIR}/etc/modules-load.d/otbr.conf"
+
 # Seed Home Assistant config (unless one already exists — preserves
 # operator edits on a future re-bake).
 HA="${DATA_DIR}/homeassistant"


### PR DESCRIPTION
PR B (#38) and PR C (#39) both forgot to install the IPv6
netfilter kernel modules OTBR needs to route between Thread and
the LAN backbone. The runbook §2.1 covers it for the manual setup;
the automated install paths skipped it.

Without these modules, OTBR comes up, vents join the Thread mesh,
and SRP registration succeeds — but matter-server's
address-resolve times out and HA shows every vent Unavailable
forever. Not a build/install failure, just a runtime symptom that
looks like a different bug.

This PR adds the modules-load.d snippet to both paths:

- pi/config/modules-load.d/otbr.conf — source of truth.
- pi/install.sh now installs it to /etc/modules-load.d/otbr.conf
  AND modprobes both modules so the first compose up works without
  a reboot.
- The sd-image bake (sd-image/.../02-copy-runtime/01-run.sh) writes
  the same file into the rootfs; the fresh-boot kernel loads it
  via systemd-modules-load.service.

## Test plan

- [x] bash -n clean on install.sh and 01-run.sh.
- [x] install.sh --dry-run shows the install + modprobe lines in
  the expected order (between .env setup and HA config seeding).
- [ ] Reviewer: re-bake the SD image (push triggers sd-image.yml
  since pi/** is in its path filter) and confirm:
  - /etc/modules-load.d/otbr.conf is in the rootfs (mount the .img
    locally, or boot a Pi and ls)
  - After boot, lsmod | grep ip6_ shows both modules loaded