### PR TITLE
Add smart-vent-provision image subcommand (write SD from hub release)

### DIFF
--- a/tools/provision/README.md
+++ b/tools/provision/README.md
@@ -16,6 +16,7 @@ done from the smart-vent mobile app at install time.
 | Capture | Provider | `smart-vent-provision capture` | Reads the post-boot serial log, records each board's EUI-64 / Matter QR / pairing code into a per-kit `inventory.json`. |
 | Label | Provider | `smart-vent-provision labels` | Renders an Avery 5160 sticker sheet from the inventory. Sticker goes on the physical vent. |
 | Quick-start | Provider | `smart-vent-provision kit-card` | Renders the one-page card that ships in the box. |
+| SD image | Provider | `smart-vent-provision image` | Pulls the hub `.img.xz` from the latest `hub-v*` GitHub release, sha256-verifies it, and `xz \| dd`s it onto the SD card. |
 | **Commission** | **Client** | **smart-vent mobile app** | **Scans the sticker QR, pairs the vent into the client's HA fabric, picks the room/floor.** |
 
 The mobile app is a separate project (Flutter, single codebase for
@@ -90,6 +91,22 @@ smart-vent-provision labels   --kit kit-acme-2026-06-001  # -> labels.pdf
 smart-vent-provision kit-card --kit kit-acme-2026-06-001 \
   --ap-password 'changeMe' --support-contact 'help@smart-vent.example'
 ```
+
+### Write the SD card
+
+```bash
+# Pulls the latest hub-v* GH release, sha256-verifies, dd's onto /dev/sdb.
+sudo smart-vent-provision image --device /dev/sdb
+
+# Pin to a specific tag instead of latest:
+sudo smart-vent-provision image --device /dev/sdb --hub-tag hub-v0.1.0
+```
+
+Refuses to write to anything that isn't a whole-disk block device
+(catches the common `/dev/sdb1` partition mistake) and prompts for
+confirmation before clobbering the device. `--yes` skips the prompt
+for automation. Needs `xz` and `dd` on `PATH` — both ship in any
+Debian/Ubuntu base install.
 
 ## Inventory schema
 

--- a/tools/provision/smart_vent_provision/cli.py
+++ b/tools/provision/smart_vent_provision/cli.py
@@ -14,6 +14,8 @@ same thing):
              back to back.
   labels   — render an Avery 5160 sheet of stickers from the inventory.
   kit-card — render the one-page client quick-start PDF.
+  image    — write the hub SD-card image (pulled from a hub-v* GH
+             release) to a removable block device.
 
 Run `smart-vent-provision <command> --help` for details.
 """
@@ -26,7 +28,17 @@ from pathlib import Path
 
 import click
 
-from . import __version__, devices, flasher, kit_card, labels, release, serial_capture
+from . import (
+    __version__,
+    devices,
+    flasher,
+    hub_release,
+    imager,
+    kit_card,
+    labels,
+    release,
+    serial_capture,
+)
 from .inventory import Inventory, Vent
 
 DEFAULT_KIT_ROOT = Path.cwd() / "kits"
@@ -307,6 +319,65 @@ def kit_card_cmd(
         support_contact=support_contact,
     )
     click.echo(f"Wrote {out}")
+
+
+# ----------------------------------------------------------------- image
+@main.command()
+@click.option(
+    "--device", required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Whole-disk block device to write to, e.g. /dev/sdb. "
+    "WIPES ALL DATA on the device.",
+)
+@click.option(
+    "--hub-tag", type=str, default=None,
+    help="Pin to a specific hub release tag (default: latest hub-v*).",
+)
+@click.option(
+    "--yes", is_flag=True, default=False,
+    help="Skip the confirmation prompt. Use in scripts; otherwise the CLI "
+    "prints the device summary and waits for explicit yes.",
+)
+def image(device: Path, hub_tag: str | None, yes: bool) -> None:
+    """Write the hub SD-card image to a removable block device.
+
+    Pulls the .img.xz from the hub-v* GitHub release into the local
+    cache (~/.cache/smart-vent/hub/<tag>/), sha256-verifies it, then
+    streams xz | dd onto the device.
+
+    Run as root (sudo) — dd to a block device needs it.
+    """
+    try:
+        imager.assert_block_device(device)
+    except imager.ImageWriteError as e:
+        raise click.ClickException(str(e)) from None
+
+    click.echo(f"Fetching hub release{' ' + hub_tag if hub_tag else ' (latest)'}...")
+    try:
+        bundle = hub_release.fetch(hub_tag)
+    except hub_release.HubReleaseError as e:
+        raise click.ClickException(str(e)) from None
+
+    size_mb = bundle.size_bytes // (1024 * 1024)
+    click.echo(f"  version: {bundle.version}")
+    click.echo(f"  image:   {bundle.image_path.name} ({size_mb} MB)")
+    click.echo(f"  sha256:  {bundle.sha256}")
+    click.echo("")
+
+    if not yes:
+        click.echo(click.style(
+            f"About to OVERWRITE {device}. Everything on it will be lost.",
+            fg="red", bold=True,
+        ))
+        click.confirm("Proceed?", abort=True)
+
+    click.echo(f"Writing to {device} (xz | dd, ~5-15 min)...")
+    try:
+        imager.write_image(bundle.image_path, device)
+    except imager.ImageWriteError as e:
+        raise click.ClickException(str(e)) from None
+
+    click.echo(click.style("Done. You can now eject the SD card and boot it.", fg="green"))
 
 
 # --------------------------------------------------------------- helpers

--- a/tools/provision/smart_vent_provision/hub_release.py
+++ b/tools/provision/smart_vent_provision/hub_release.py
@@ -1,0 +1,164 @@
+"""Fetch hub SD-image releases from GitHub.
+
+Companion to `release` (which handles firmware-v* releases). The hub
+workflow on every hub-v* tag publishes a release with:
+
+    smart-vent-hub-<ver>.img.xz
+    smart-vent-hub-<ver>.img.xz.sha256
+
+This module downloads + sha256-verifies the image into a cache dir.
+The `image` CLI subcommand then writes the cached file to an SD card.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import platformdirs
+import requests
+
+GITHUB_API = "https://api.github.com"
+REPO = "EtaCassiopeia/smart-vent"
+DEFAULT_CACHE_ROOT = Path(platformdirs.user_cache_dir("smart-vent")) / "hub"
+
+# What the sd-image workflow publishes.
+IMG_GLOB = re.compile(r"^smart-vent-hub-.*\.img\.xz$")
+SHA_SUFFIX = ".sha256"
+
+
+@dataclass
+class HubBundle:
+    version: str            # tag, e.g. "hub-v0.1.0"
+    image_path: Path        # cached .img.xz
+    sha256: str             # hex digest of the image
+    cache_dir: Path
+
+    @property
+    def size_bytes(self) -> int:
+        return self.image_path.stat().st_size
+
+
+class HubReleaseError(RuntimeError):
+    """Raised when a hub release can't be fetched or verified."""
+
+
+def _resolve_tag(tag: str | None) -> str:
+    if tag and tag != "latest":
+        return tag
+    url = f"{GITHUB_API}/repos/{REPO}/releases"
+    resp = requests.get(url, params={"per_page": 30}, timeout=15)
+    resp.raise_for_status()
+    for rel in resp.json():
+        name = rel.get("tag_name", "")
+        if name.startswith("hub-v") and not rel.get("draft") and not rel.get("prerelease"):
+            return name
+    raise HubReleaseError("no published hub-v* release found")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(64 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _expected_sha(sha_file: Path) -> str:
+    """Read the sha256 hex digest from a `sha256sum`-style file."""
+    line = sha_file.read_text().strip().split()
+    if not line:
+        raise HubReleaseError(f"{sha_file} is empty")
+    return line[0].lower()
+
+
+def _download(url: str, dest: Path, session: requests.Session) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with session.get(url, stream=True, timeout=120) as r:
+        r.raise_for_status()
+        with dest.open("wb") as f:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
+
+
+def fetch(tag: str | None = None, *, cache_root: Path | None = None) -> HubBundle:
+    """Fetch (or load from cache) the hub SD-image release for `tag`.
+
+    Verifies the image's sha256 against the published .sha256 file. If
+    the cache is already valid, no network calls happen.
+    """
+    cache_root = cache_root or DEFAULT_CACHE_ROOT
+    resolved = _resolve_tag(tag)
+    cache_dir = cache_root / resolved
+    img_cache, sha_cache = _cached_paths(cache_dir)
+
+    if _cache_is_complete_and_valid(img_cache, sha_cache):
+        return _build_bundle(resolved, cache_dir, img_cache, sha_cache)
+
+    _populate_cache(resolved, cache_dir)
+    img_cache, sha_cache = _cached_paths(cache_dir)
+    _verify(img_cache, sha_cache)
+    return _build_bundle(resolved, cache_dir, img_cache, sha_cache)
+
+
+def _cached_paths(cache_dir: Path) -> tuple[Path | None, Path | None]:
+    if not cache_dir.exists():
+        return None, None
+    img = next((p for p in cache_dir.iterdir() if IMG_GLOB.match(p.name)), None)
+    sha = cache_dir / f"{img.name}{SHA_SUFFIX}" if img else None
+    if sha is not None and not sha.exists():
+        sha = None
+    return img, sha
+
+
+def _cache_is_complete_and_valid(img: Path | None, sha: Path | None) -> bool:
+    if img is None or sha is None:
+        return False
+    try:
+        _verify(img, sha)
+    except HubReleaseError:
+        return False
+    return True
+
+
+def _populate_cache(tag: str, cache_dir: Path) -> None:
+    url = f"{GITHUB_API}/repos/{REPO}/releases/tags/{tag}"
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    rel = resp.json()
+    assets = {a["name"]: a["browser_download_url"] for a in rel.get("assets", [])}
+
+    img_name = next((n for n in assets if IMG_GLOB.match(n)), None)
+    if img_name is None:
+        raise HubReleaseError(
+            f"release {tag} has no smart-vent-hub-*.img.xz asset (have: {sorted(assets)})"
+        )
+    sha_name = f"{img_name}{SHA_SUFFIX}"
+    if sha_name not in assets:
+        raise HubReleaseError(f"release {tag} has {img_name} but no {sha_name}")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    with requests.Session() as session:
+        _download(assets[img_name], cache_dir / img_name, session)
+        _download(assets[sha_name], cache_dir / sha_name, session)
+
+
+def _verify(img: Path, sha: Path) -> None:
+    expected = _expected_sha(sha)
+    actual = _sha256(img)
+    if actual != expected:
+        raise HubReleaseError(
+            f"sha256 mismatch for {img.name}: expected {expected}, got {actual}"
+        )
+
+
+def _build_bundle(version: str, cache_dir: Path, img: Path, sha: Path) -> HubBundle:
+    return HubBundle(
+        version=version,
+        image_path=img,
+        sha256=_expected_sha(sha),
+        cache_dir=cache_dir,
+    )

--- a/tools/provision/smart_vent_provision/imager.py
+++ b/tools/provision/smart_vent_provision/imager.py
@@ -1,0 +1,61 @@
+"""Write a .img.xz to a removable block device.
+
+Uses xz | dd via subprocess so the decompression streams without
+materializing the uncompressed image to disk first.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+class ImageWriteError(RuntimeError):
+    """Raised when dd/xz fails."""
+
+
+def assert_block_device(path: Path) -> None:
+    """Refuse to write to anything that isn't a real block device.
+
+    Catches the common mistake of pointing the CLI at a regular file
+    (or a partition like /dev/sdX1 instead of the whole disk /dev/sdX).
+    """
+    if not path.exists():
+        raise ImageWriteError(f"{path} does not exist")
+    if not path.is_block_device():
+        raise ImageWriteError(f"{path} is not a block device (refusing to write)")
+    # Partition path heuristic: ends with a digit on /dev/sd*, /dev/nvme*p, /dev/mmcblk*p.
+    name = path.name
+    if name[-1:].isdigit() and not name.startswith(("loop", "ram")):
+        raise ImageWriteError(
+            f"{path} looks like a partition (ends in a digit). Pass the whole-disk "
+            "device, e.g. /dev/sdb instead of /dev/sdb1."
+        )
+
+
+def write_image(image: Path, device: Path, *, bs: str = "4M") -> None:
+    """Stream `image` (xz-compressed) onto `device`.
+
+    Both `image` and `device` must already exist; caller is responsible
+    for `sudo` and for any safety prompts before invoking.
+    """
+    if not image.exists():
+        raise ImageWriteError(f"{image} does not exist")
+    assert_block_device(device)
+
+    for tool in ("xz", "dd"):
+        if not shutil.which(tool):
+            raise ImageWriteError(f"{tool} not found on PATH")
+
+    cmd = f"xz -dc {_quote(image)} | dd of={_quote(device)} bs={bs} status=progress conv=fsync"
+    result = subprocess.run(["bash", "-c", cmd], check=False)
+    if result.returncode != 0:
+        raise ImageWriteError(f"image write failed (exit {result.returncode})")
+
+
+def _quote(p: Path | str) -> str:
+    s = str(p)
+    if all(c.isalnum() or c in "/._-" for c in s):
+        return s
+    return "'" + s.replace("'", "'\\''") + "'"

--- a/tools/provision/tests/test_hub_release.py
+++ b/tools/provision/tests/test_hub_release.py
@@ -1,0 +1,109 @@
+"""Test hub_release.fetch — the GitHub SD-image downloader.
+
+Mocks GH API + asset downloads via `responses`. Verifies:
+  - resolves "latest" tag
+  - downloads expected file set
+  - sha256-verifies against the .sha256 file
+  - raises HubReleaseError on mismatch / missing assets
+  - re-fetch hits the cache
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import responses
+
+from smart_vent_provision import hub_release as hr
+
+
+SAMPLE_IMG = b"\xfd7zXZ" + b"FAKE-XZ-CONTENT" * 64  # not a real xz, just bytes
+EXPECTED_SHA = hashlib.sha256(SAMPLE_IMG).hexdigest()
+
+
+def _sha_body(filename: str) -> bytes:
+    return f"{EXPECTED_SHA}  {filename}\n".encode()
+
+
+def _register_release(tag: str, *, img_size: int = len(SAMPLE_IMG)) -> tuple[str, str]:
+    img_name = f"smart-vent-hub-{tag}.img.xz"
+    sha_name = f"{img_name}.sha256"
+    base = f"https://example.com/{tag}"
+    assets = [
+        {"name": img_name, "browser_download_url": f"{base}/{img_name}"},
+        {"name": sha_name, "browser_download_url": f"{base}/{sha_name}"},
+    ]
+    responses.add(
+        responses.GET,
+        f"{hr.GITHUB_API}/repos/{hr.REPO}/releases/tags/{tag}",
+        json={"tag_name": tag, "assets": assets},
+    )
+    responses.add(responses.GET, f"{base}/{img_name}", body=SAMPLE_IMG)
+    responses.add(responses.GET, f"{base}/{sha_name}", body=_sha_body(img_name))
+    return img_name, sha_name
+
+
+@responses.activate
+def test_fetch_explicit_tag_downloads_and_verifies(tmp_path: Path):
+    img_name, _ = _register_release("hub-v0.1.0")
+    bundle = hr.fetch("hub-v0.1.0", cache_root=tmp_path)
+    assert bundle.version == "hub-v0.1.0"
+    assert bundle.image_path.name == img_name
+    assert bundle.sha256 == EXPECTED_SHA
+    assert bundle.size_bytes == len(SAMPLE_IMG)
+
+
+@responses.activate
+def test_fetch_cached_skips_network(tmp_path: Path):
+    _register_release("hub-v0.1.0")
+    hr.fetch("hub-v0.1.0", cache_root=tmp_path)
+
+    # Wipe registered responses; second fetch should not hit the network.
+    responses.reset()
+    bundle = hr.fetch("hub-v0.1.0", cache_root=tmp_path)
+    assert bundle.version == "hub-v0.1.0"
+
+
+@responses.activate
+def test_fetch_resolves_latest(tmp_path: Path):
+    _register_release("hub-v0.2.0")
+    responses.add(
+        responses.GET,
+        f"{hr.GITHUB_API}/repos/{hr.REPO}/releases",
+        json=[
+            {"tag_name": "firmware-v0.1.0", "draft": False, "prerelease": False},
+            {"tag_name": "hub-v0.2.0", "draft": False, "prerelease": False},
+            {"tag_name": "hub-v0.1.0", "draft": False, "prerelease": False},
+        ],
+    )
+    bundle = hr.fetch(None, cache_root=tmp_path)
+    # Returns the first matching hub-v* tag in the listed order.
+    assert bundle.cache_dir == tmp_path / "hub-v0.2.0"
+
+
+@responses.activate
+def test_fetch_raises_on_sha256_mismatch(tmp_path: Path):
+    tag = "hub-v0.1.0"
+    img_name, sha_name = _register_release(tag)
+    # Replace the image with corrupted content.
+    responses.remove(responses.GET, f"https://example.com/{tag}/{img_name}")
+    responses.add(
+        responses.GET,
+        f"https://example.com/{tag}/{img_name}",
+        body=b"NOT THE IMAGE",
+    )
+    with pytest.raises(hr.HubReleaseError):
+        hr.fetch(tag, cache_root=tmp_path)
+
+
+@responses.activate
+def test_fetch_raises_when_release_missing_assets(tmp_path: Path):
+    responses.add(
+        responses.GET,
+        f"{hr.GITHUB_API}/repos/{hr.REPO}/releases/tags/hub-v0.1.0",
+        json={"tag_name": "hub-v0.1.0", "assets": []},
+    )
+    with pytest.raises(hr.HubReleaseError):
+        hr.fetch("hub-v0.1.0", cache_root=tmp_path)

--- a/tools/provision/tests/test_imager.py
+++ b/tools/provision/tests/test_imager.py
@@ -1,0 +1,50 @@
+"""Test the safety guards on imager.write_image / assert_block_device.
+
+Block-device-specific work is exercised via a synthetic device (tmpfile
+that lies via mock); the actual dd path is integration-only and not in
+this test suite.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from smart_vent_provision import imager
+
+
+def test_assert_block_device_rejects_regular_file(tmp_path: Path):
+    f = tmp_path / "not-a-device.img"
+    f.write_bytes(b"hello")
+    with pytest.raises(imager.ImageWriteError, match="not a block device"):
+        imager.assert_block_device(f)
+
+
+def test_assert_block_device_rejects_missing(tmp_path: Path):
+    with pytest.raises(imager.ImageWriteError, match="does not exist"):
+        imager.assert_block_device(tmp_path / "ghost")
+
+
+def test_assert_block_device_rejects_partition_path():
+    # Use a fake path that ends in a digit and pretend it's a block device.
+    fake = Path("/dev/sdb1")
+    with patch.object(Path, "exists", return_value=True), \
+         patch.object(Path, "is_block_device", return_value=True):
+        with pytest.raises(imager.ImageWriteError, match="looks like a partition"):
+            imager.assert_block_device(fake)
+
+
+def test_assert_block_device_accepts_whole_disk():
+    fake = Path("/dev/sdb")
+    with patch.object(Path, "exists", return_value=True), \
+         patch.object(Path, "is_block_device", return_value=True):
+        # Should NOT raise.
+        imager.assert_block_device(fake)
+
+
+# The full write_image path (xz | dd) is integration-only and exercised
+# manually with `smart-vent-provision image --device /dev/sdX`. The two
+# safety guards above are the unit-test-worthy bits.


### PR DESCRIPTION
Closes the deferred \`image\` item from PR #36. The CLI can now pull
a tagged \`hub-v*\` GitHub Release, sha256-verify the \`.img.xz\`,
and stream it onto an SD card via \`xz | dd\`.

\`\`\`bash
sudo smart-vent-provision image --device /dev/sdb
sudo smart-vent-provision image --device /dev/sdb --hub-tag hub-v0.1.0
\`\`\`

## New modules

- \`hub_release.py\` — GitHub Releases fetcher for
  \`smart-vent-hub-*.img.xz\` + \`.sha256\`. Structured like
  \`release.py\` (firmware): tag resolution, asset download, sha256
  verify, caching to \`~/.cache/smart-vent/hub/<tag>/\`.
- \`imager.py\` — \`dd\` wrapper with two safety guards:
  - Refuses anything that isn't a real block device.
  - Refuses partition paths like \`/dev/sdb1\` (\`/dev/sdb\` is what
    you want).

CLI prints version, size, sha256 of the image before doing anything,
then prompts for explicit confirmation unless \`--yes\` is passed.

## Tests

- 23 passing (up from 14).
- New tests cover hub_release fetch + sha256 verify with mocked GH,
  and the imager safety guards.
- The full \`xz | dd\` path is integration-only — exercised by
  actually running the subcommand on a spare SD card.

## Once hub-v0.1.0 lands

The tag \`hub-v0.1.0\` is now pushed (separately from this PR) and
its bake is in flight. After that release publishes, the \`image\`
subcommand will resolve \`latest\` to it automatically.