### PR TITLE
Document the mobile-app contract + screen spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ cloud dependency. The Pi is the entire backend.
   the Pi from scratch, build the firmware, flash a new vent, commission it via HA,
   assign it to a room, and add the next one. Plus a symptom-driven troubleshooting
   matrix.
+- **[docs/mobile-api.md](docs/mobile-api.md)** — API contract the smart-vent mobile
+  app builds against (matter-server WS, HA REST, mDNS).
+- **[docs/mobile-app-spec.md](docs/mobile-app-spec.md)** — screen-by-screen spec
+  the Flutter team works from.
 
 ## Repo layout
 

--- a/docs/mobile-api.md
+++ b/docs/mobile-api.md
@@ -1,0 +1,206 @@
+# Mobile-app API contract
+
+The smart-vent mobile app talks to a client's hub over the LAN. It
+does **not** speak Matter or BLE itself — the Pi (`matter-server`)
+handles BLE commissioning and the Matter fabric. The app's surface
+area is two HTTP/WS endpoints exposed by the hub.
+
+This document is the contract the [smart-vent-app](#) Flutter repo
+builds against. Anything the app touches lives here.
+
+## Endpoints exposed by the hub
+
+| URL | Server | Purpose |
+|---|---|---|
+| `ws://<hub>:5580/ws` | `matter-server` | Commissioning (BLE PASE → fabric → CASE), node attribute reads/writes. JSON-over-WebSocket. |
+| `http://<hub>:8123/api/...` | Home Assistant | Areas, floors, entities, services. Long-lived access token auth. |
+| `_smart-vent._tcp.local.` (mDNS) | hub | Discovery. Advertised by HA's mDNS service plus a small helper on the Pi (TBD; not yet implemented). |
+
+`<hub>` is either the mDNS-resolved hostname (e.g. `smart-vent.local`)
+or a manual IP the user enters during onboarding.
+
+## Auth model
+
+- **HA**: long-lived access token. The app obtains one via HA's
+  built-in OAuth-style flow on first run, stores it in
+  keychain/keystore, sends it as `Authorization: Bearer <token>` on
+  every REST call.
+- **matter-server**: no auth. The WS is open to anything that can
+  reach `localhost:5580` on the hub. The hub is on the LAN behind
+  the home router; we trust the LAN perimeter. (Future hardening: a
+  small reverse proxy on the Pi that requires the HA token for
+  matter-server too.)
+
+## Discovery: mDNS
+
+The hub advertises:
+
+```
+_smart-vent._tcp.local.   port=8123
+   txt: version=hub-v0.1.0
+        ha_ws=ws://<hub>:8123/api/websocket
+        matter_ws=ws://<hub>:5580/ws
+```
+
+App's first-run flow: browse for `_smart-vent._tcp.local.`, present
+matches to the user, fall back to a manual-IP input. If multiple
+hubs are on the same LAN, the app shows the list and lets the user
+pick.
+
+## matter-server WebSocket
+
+On connect, the server sends a "hello" message with its info, then
+the app sends commands. The library docs at
+<https://github.com/home-assistant-libs/python-matter-server> have
+the full schema. The app needs three commands.
+
+### `commission_with_code`
+
+The core of "add a vent": app scanned the sticker, has a Matter QR
+payload (or the equivalent manual pairing code), sends:
+
+```json
+{
+  "message_id": "uuid-1",
+  "command": "commission_with_code",
+  "args": {
+    "code": "MT:Y3.13OTB00KA0648G00",
+    "network_only": false
+  }
+}
+```
+
+`network_only: false` means full BLE PASE + Thread credential push +
+CASE handoff. The server streams progress events back via the same
+WS, and finally returns the assigned `node_id`.
+
+Response shape (the success case):
+
+```json
+{
+  "message_id": "uuid-1",
+  "result": { "node_id": 14, "available": true }
+}
+```
+
+Failure: `result` absent, `error_code` set. Common codes:
+
+| code | meaning | what the app should do |
+|---|---|---|
+| `pairing_failed` | BLE PASE didn't complete | Power-cycle the vent (resets the 15-min fast-adv window), retry |
+| `address_resolve_failed` | Thread credentials pushed but mDNS/CASE timed out | Wait 30s and re-attempt; OTBR may still be propagating |
+| `node_already_exists` | The same QR code was paired before | Treat as success; fetch the existing node by EUI64 |
+
+### `get_nodes`
+
+List of nodes the fabric knows about. The app uses this to:
+- Show "X vents commissioned" on the home screen.
+- Skip commissioning if the user re-scans a sticker that's already
+  paired.
+
+```json
+{
+  "message_id": "uuid-2",
+  "command": "get_nodes",
+  "args": {}
+}
+```
+
+Response: `result` is a list of node dicts with `node_id`,
+`available`, and `attributes` (a flat map of `<endpoint>/<cluster>/<attr>`
+→ value).
+
+### `device_command`
+
+Send a command to a node. The app's "test the vent" button uses
+this after commissioning to confirm the vent moves.
+
+```json
+{
+  "message_id": "uuid-3",
+  "command": "device_command",
+  "args": {
+    "node_id": 14,
+    "endpoint_id": 1,
+    "cluster_id": 258,
+    "command_name": "DownOrClose",
+    "payload": {}
+  }
+}
+```
+
+`258` is the WindowCovering cluster ID.
+
+## Home Assistant REST API
+
+After commissioning, the app talks to HA to:
+1. Create the Area for the vent's room (if it doesn't exist) and
+   the Floor it belongs to.
+2. Move the new cover entity into that Area.
+3. Rename the entity to `cover.<room>_vent_<n>`.
+
+All via REST + WebSocket. Two endpoints matter most.
+
+### `GET /api/states`
+
+Lists every entity HA knows about. The app filters
+`startswith("cover.")` and `attributes.friendly_name contains "Vent"`
+to find the just-commissioned cover.
+
+Auth: `Authorization: Bearer <long-lived-token>`.
+
+### `POST /api/services/<domain>/<service>`
+
+Service call. The app uses three:
+
+| call | purpose |
+|---|---|
+| `cover.open_cover` / `cover.close_cover` | "Test the vent" buttons during onboarding |
+| `cover.set_cover_position` | Per-vent slider in the UI |
+
+### Area + floor CRUD: WebSocket API
+
+HA's REST API doesn't cover area/floor management; the WS API does.
+URL: `ws://<hub>:8123/api/websocket`. The app sends the token in
+the auth handshake.
+
+| ws command | purpose |
+|---|---|
+| `config/area_registry/list` | List existing Areas (so the app can show "pick an existing room" UX before offering "create new"). |
+| `config/area_registry/create` | Create an Area (room). Args: `name`, `floor_id?`. |
+| `config/floor_registry/list` | List Floors. |
+| `config/floor_registry/create` | Create a Floor. Args: `name`. |
+| `config/device_registry/update` | Set a device's `area_id`. Args: `device_id`, `area_id`. |
+| `config/entity_registry/update` | Rename an entity. Args: `entity_id`, `new_entity_id`, `name`. |
+
+Full WS message schema is in HA's developer docs at
+<https://developers.home-assistant.io/docs/api/websocket/>.
+
+## Error model
+
+Both servers return errors in the same shape over WS:
+
+```json
+{ "message_id": "uuid", "error_code": "...", "details": "..." }
+```
+
+HA REST errors are HTTP status + JSON body with `message`. App should
+display the `details` / `message` verbatim on a failure screen — both
+servers' messages are end-user actionable.
+
+## Versioning
+
+- `mDNS TXT version=hub-v0.1.0` tells the app what hub it's talking
+  to. The app uses this to bail out cleanly if it meets a hub that's
+  newer than it knows about.
+- This document is versioned with the repo; bumping breaking changes
+  to the contract goes via PR review.
+
+## Out of scope (today)
+
+- **Phone-side BLE PASE.** The app doesn't run a Matter SDK; the Pi
+  does the BLE pairing. The phone just has to be on the same LAN
+  as the Pi during commissioning.
+- **Hub bootstrap.** Joining the hub to the home WiFi is the Pi's
+  first-boot wizard (`pi/firstboot/`); the app isn't involved.
+- **Voice integrations.** Out of v1 scope per the design plan.

--- a/docs/mobile-app-spec.md
+++ b/docs/mobile-app-spec.md
@@ -1,0 +1,174 @@
+# smart-vent mobile app — spec
+
+The smart-vent mobile app is the **client-facing** half of the
+deployment plan (workstream 6). It lives in a separate Flutter repo
+(`smart-vent-app`, not in this repo); this document defines what it
+needs to do. The API contract it builds against is in
+[`mobile-api.md`](mobile-api.md).
+
+## Audience + scope
+
+The app is for the **end client**, not the provider. The provider
+uses `smart-vent-provision` to prep kits; the client uses the app
+to turn a freshly delivered kit into a working installation.
+
+The app handles three things:
+
+1. Pair the phone to the user's hub (mDNS discovery + HA token).
+2. Add each vent to the user's home: scan QR sticker, the hub
+   commissions it, the user picks a room.
+3. Day-2: a thin "control my vents" surface so a user can open/
+   close a vent without opening HA. (HA is still available; we just
+   want one-tap control for non-techy users.)
+
+Anything more complex than that — automations, advanced configuration,
+multi-user sharing — happens in HA's own app. We don't reimplement
+HA.
+
+## Why Flutter + WS-API approach
+
+The phone **does not** run a Matter SDK. The Pi does. Concretely:
+
+- The phone is on the home WiFi.
+- The Pi has BLE and 802.15.4 radios; it's the Matter controller.
+- The app sends JSON to `ws://<hub>:5580/ws` and HA's REST.
+
+This was the major decision documented in the design plan
+(workstream 6.1). The trade-off: the Pi must be within BLE range
+(~10 m) of each vent during commissioning. That's fine because OTBR
+needs the Pi central in the house anyway.
+
+Flutter is the single-codebase choice (Android + iOS); no platform
+forks.
+
+## Screen-by-screen flow
+
+### Screen 0 — Welcome / discovery
+
+- Logo, "Get started" button.
+- On tap, browse mDNS for `_smart-vent._tcp.local.`.
+- If one hub found, auto-select it. If multiple, list them with
+  TXT-record version. If none, "Enter hub address" manual input.
+- "Where do I find this?" link → kit-card photo with the AP
+  SSID/password shown.
+
+### Screen 1 — HA token
+
+- "We need to connect to your hub" panel.
+- "Sign in to Home Assistant" button → opens HA's OAuth flow in a
+  WebView at `http://<hub>:8123/auth/authorize?...`.
+- On callback, store the long-lived access token in
+  keychain/keystore. Verify with a `GET /api/` ping.
+
+### Screen 2 — Home
+
+After auth, the home screen shows:
+
+- A list of already-commissioned vents (from `get_nodes` →
+  filter for WindowCovering), grouped by HA Area.
+- Per vent: name, room, current position (% open), open/close
+  buttons.
+- Floating "+" button → **Add a vent** (Screen 3).
+- Top-right gear → settings (re-auth, change hub, factory reset).
+
+### Screen 3 — Add a vent
+
+- "Point at the sticker" camera viewport.
+- Auto-detect Matter QR (the `MT:...` prefix). Once detected:
+  vibrate, show a "Pair this vent?" confirmation with the last 4
+  of the EUI (from the sticker).
+- On confirm: full-screen progress card. Streams matter-server's
+  WS events:
+  1. "Connecting over Bluetooth…" (PASE)
+  2. "Sending Thread credentials…" (push)
+  3. "Confirming…" (CASE)
+- On failure: show the error code from
+  [`mobile-api.md`](mobile-api.md#commission_with_code) verbatim
+  + a one-line plain-English explanation + "Try again" button.
+- On success: → Screen 4.
+
+### Screen 4 — Place this vent
+
+- "Which room is this vent in?"
+- Picker reads existing HA Areas. Below the picker: "+ New room"
+  → name input, optional Floor picker (or "+ New floor").
+- "Optional: give this vent a name" text field. Defaults to the
+  next-free `<room>-vent-<n>` slot.
+- Continue → calls HA WS:
+  1. Create the Area + Floor if needed
+  2. Set the cover entity's `area_id`
+  3. Rename the entity to `cover.<room>_vent_<n>` (slugified)
+- → Screen 5.
+
+### Screen 5 — Test the vent
+
+- "Let's make sure it works." Big "Open" + "Close" buttons.
+- On tap: `device_command` to the WindowCovering cluster. Watch
+  for the position attribute to update; show the new position.
+- "Done" button → back to Home (Screen 2) with the new vent
+  listed.
+
+### Screen 6 — Per-vent control (from Home, tap a vent)
+
+- Cover entity name + room.
+- Big position slider (0-100%).
+- "Open", "Close", "Set to 50%" quick buttons.
+- "Rename" / "Move to another room" / "Remove vent" overflow menu.
+- "Identify" button → calls Matter Identify cluster, vent wiggles.
+
+### Screen 7 — Settings
+
+- Hub: name, version (from mDNS TXT), "Switch hub" button.
+- Account: HA user email, "Sign out" (clears token).
+- About: app version, contract version, link to docs.
+- "Factory reset" — clears the keychain entry and returns to
+  Screen 0.
+
+## State-management notes (for the implementer)
+
+- Cache `get_nodes` for ~30s; refresh on focus.
+- Stream live position updates via matter-server's subscription
+  mechanism (`start_listening` then attribute-changed events) for
+  the Home screen and per-vent screen.
+- WS reconnection: exponential backoff, max 60s. Show a
+  non-blocking "Reconnecting…" banner; don't gate the UI.
+- Token refresh: HA's long-lived token doesn't expire (by design).
+  No refresh dance needed.
+
+## Branding hooks
+
+Provider can ship a white-labeled build by overriding:
+
+- `assets/logo.svg`
+- `lib/theme.dart` — primary color, accent, dark variant
+- `strings.arb` — support email, app name
+
+These are pulled at build time from `--dart-define` flags so the
+same CI workflow produces both a default build and per-provider
+builds.
+
+## Out of scope (for v1)
+
+- Multi-fabric / Apple Home commissioning. Matter spec supports
+  multi-admin handoff; we punt it to v2.
+- In-app firmware updates for vents. OTA needs the Matter
+  OTAProvider cluster which we don't ship yet.
+- iPad / tablet-specific layouts. Phone-first for v1.
+- Notifications (filter clean reminders etc.). v2 once we figure
+  out a sensor strategy.
+
+## Build + ship
+
+- iOS: TestFlight for beta, App Store for GA. Apple developer
+  account is the provider's responsibility.
+- Android: GitHub Releases for `.apk` sideloads, Play Store for GA.
+- Same versioning scheme as the rest of the project (`app-vX.Y.Z`).
+
+## Contract changes
+
+If the hub side (matter-server commands, HA WS messages, mDNS TXT
+shape) needs to change in a way that breaks older app builds, the
+hub bumps its `_smart-vent._tcp.local.` TXT `version` field to a
+new major. The app shows a "your hub is newer than this app, please
+update" screen and refuses to commission. Provider then ships an
+app update.


### PR DESCRIPTION
Workstream 6 of the deployment plan defined a separate Flutter repo
(smart-vent-app) for the client mobile app. This repo doesn't build
the app, but it owns the contract.

## docs/mobile-api.md

The API surface the app builds against:

- Hub endpoints (matter-server WS at :5580, HA REST at :8123, mDNS
  service record for discovery)
- Auth (HA long-lived token; matter-server unauth on LAN, trust
  perimeter, future hardening notes)
- The three matter-server commands the app uses
  (\`commission_with_code\`, \`get_nodes\`, \`device_command\`) with
  request/response shapes and the failure-code table
- HA REST + WebSocket commands the app needs for Areas/Floors/
  entities (the WS area_registry / floor_registry / device_registry /
  entity_registry CRUD)
- Error model + versioning via mDNS TXT (so older app builds bail
  cleanly against a newer hub)

## docs/mobile-app-spec.md

The Flutter team's spec:

- 7-screen flow from first-launch discovery through per-vent
  control
- State-management notes (subscription strategy, reconnection,
  caching)
- Branding hooks for white-labeling
- Build + ship targets (TestFlight / Play Store)
- Explicit out-of-scope: phone-side BLE PASE, multi-fabric handoff,
  OTA, notifications

README cross-links both files.

No code, no CI — this is just the contract that needs to exist
before the mobile team starts.