### PR TITLE
Defer the custom mobile app; point clients at the HA app

### DIFF
--- a/docs/mobile-app-spec.md
+++ b/docs/mobile-app-spec.md
@@ -1,10 +1,22 @@
 # smart-vent mobile app — spec
 
-The smart-vent mobile app is the **client-facing** half of the
-deployment plan (workstream 6). It lives in a separate Flutter repo
-(`smart-vent-app`, not in this repo); this document defines what it
-needs to do. The API contract it builds against is in
-[`mobile-api.md`](mobile-api.md).
+> **Status: deferred / reference only.** As of v1, smart-vent vents
+> commission via the Home Assistant Companion app out of the box —
+> client scans the QR sticker on each vent, picks a room, done. A
+> custom branded app duplicates the HA app's commissioning flow
+> without adding engineering value; the only reasons to build one
+> are branding or a streamlined onboarding UX for non-technical
+> clients. This document remains as the contract a future
+> branded-app effort would target. The companion contract document
+> [`mobile-api.md`](mobile-api.md) is useful regardless — it
+> describes what any integration (custom app, automation script,
+> third-party tool) would talk to.
+
+The smart-vent mobile app, **if built**, would be the
+**client-facing** half of the deployment plan (workstream 6). It
+would live in a separate Flutter repo (`smart-vent-app`, not in this
+repo); this document defines what it needs to do. The API contract
+it would build against is in [`mobile-api.md`](mobile-api.md).
 
 ## Audience + scope
 

--- a/tools/provision/smart_vent_provision/kit_card.py
+++ b/tools/provision/smart_vent_provision/kit_card.py
@@ -64,19 +64,21 @@ def render_pdf(
     cursor -= 0.50 * inch
 
     pdf.setFont("Helvetica-Bold", 16)
-    pdf.drawString(0.75 * inch, cursor, "3.  Install the smart-vent app")
+    pdf.drawString(0.75 * inch, cursor, "3.  Install Home Assistant")
     cursor -= 0.30 * inch
     pdf.setFont("Helvetica", 11)
-    pdf.drawString(0.95 * inch, cursor, "Search 'smart-vent' on the App Store or Google Play.")
+    pdf.drawString(0.95 * inch, cursor, "Search 'Home Assistant' on the App Store or Google Play.")
+    cursor -= 0.20 * inch
+    pdf.drawString(0.95 * inch, cursor, "Sign in to your hub when prompted (it auto-discovers on your network).")
     cursor -= 0.50 * inch
 
     pdf.setFont("Helvetica-Bold", 16)
     pdf.drawString(0.75 * inch, cursor, "4.  Add each vent")
     cursor -= 0.30 * inch
     pdf.setFont("Helvetica", 11)
-    pdf.drawString(0.95 * inch, cursor, "In the app, tap 'Add vent' and scan the QR sticker on the vent.")
+    pdf.drawString(0.95 * inch, cursor, "Settings → Devices & services → Add Integration → Matter.")
     cursor -= 0.20 * inch
-    pdf.drawString(0.95 * inch, cursor, "Pick the room when prompted. Repeat for each vent.")
+    pdf.drawString(0.95 * inch, cursor, "Scan the QR sticker on the vent, pick its room. Repeat for each vent.")
     cursor -= 0.80 * inch
 
     pdf.setFont("Helvetica-Oblique", 10)


### PR DESCRIPTION
Acting on a design-review discussion: smart-vent vents are
Matter-over-Thread (WiFi is compiled out of the firmware), so they
commission via the standard Matter QR flow that the Home Assistant
Companion app already handles end-to-end. A custom branded mobile
app would duplicate that flow without adding engineering value;
build one only if branding or a stripped-down onboarding UX become
real product requirements.

## Two changes

- \`tools/provision/.../kit_card.py\` — step 3 of the printed client
  card now says \"Install Home Assistant\" (instead of the imaginary
  smart-vent app); step 4 walks through HA's
  Settings → Devices & services → Add Integration → Matter flow.

- \`docs/mobile-app-spec.md\` — adds a \"Status: deferred / reference
  only\" header. The doc stays in the repo as the contract a future
  branded-app effort would target, but it's no longer a v1
  deliverable.

\`docs/mobile-api.md\` is unchanged on purpose — it documents the
hub's WS + REST surface that any integration (custom app,
automation script, third-party tool) would talk to, regardless of
whether we ship a branded app.

## Test plan

- [x] \`pytest tools/provision/tests -q\` → 23 passing
- [x] Smoke-rendered \`kit-card.pdf\` with the new copy; PDF
      generates cleanly
- [ ] Reviewer: open the regenerated \`kit-card.pdf\` (run
      \`smart-vent-provision kit-card --kit kit-test ...\`) and
      confirm the new steps 3-4 read sensibly