### PR TITLE
Expose battery state via Matter Power Source cluster (#50)

### DIFF
--- a/firmware/vent-controller/components/esp_matter_bridge/include/matter_bridge.h
+++ b/firmware/vent-controller/components/esp_matter_bridge/include/matter_bridge.h
@@ -55,6 +55,18 @@ void matter_bridge_update_position(uint16_t percent100ths);
 void matter_bridge_update_operational_status(uint8_t status);
 
 /**
+ * Report battery state via the Power Source cluster's Battery feature, so
+ * Home Assistant's Matter integration can surface a battery sensor entity
+ * (see docs/battery-carrier-board.md and issue #50). No-op on USB-powered
+ * builds — just don't call this if there's no battery.
+ *
+ * @param bat_charge_level Matter BatChargeLevelEnum: 0=Ok, 1=Warning, 2=Critical
+ * @param bat_percent Battery percentage remaining, 0-100 (converted to the
+ *                     cluster's native half-percent units internally)
+ */
+void matter_bridge_update_battery(uint8_t bat_charge_level, uint8_t bat_percent);
+
+/**
  * Check if the device has been commissioned into a Matter fabric.
  * @return true if commissioned
  */

--- a/firmware/vent-controller/components/esp_matter_bridge/matter_bridge.cpp
+++ b/firmware/vent-controller/components/esp_matter_bridge/matter_bridge.cpp
@@ -12,6 +12,7 @@
 #include <app/clusters/window-covering-server/window-covering-server.h>
 #include <app/clusters/window-covering-server/window-covering-delegate.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-enums.h>
 
 static const char *TAG = "matter_bridge";
 
@@ -168,6 +169,24 @@ int matter_bridge_init(matter_position_cb_t position_cb,
         }
     }
 
+    // Add a Power Source cluster (Battery feature) to the same endpoint, so
+    // battery-powered builds can report charge level/percentage and HA's
+    // Matter integration surfaces a battery sensor entity (issue #50). Safe
+    // to add on USB-powered builds too -- matter_bridge_update_battery()
+    // just won't be called for those, so it stays at its default (Ok, 0%).
+    {
+        cluster::power_source::config_t ps_config;
+        ps_config.battery.bat_charge_level = static_cast<uint8_t>(PowerSource::BatChargeLevelEnum::kOk);
+        cluster_t *ps_cluster = cluster::power_source::create(
+            ep, &ps_config, CLUSTER_FLAG_SERVER,
+            static_cast<uint32_t>(PowerSource::Feature::kBattery));
+        if (ps_cluster) {
+            ESP_LOGI(TAG, "PowerSource cluster added (Battery feature)");
+        } else {
+            ESP_LOGE(TAG, "Could not add PowerSource cluster");
+        }
+    }
+
     // Set Basic Information cluster attributes
     endpoint_t *root_ep = endpoint::get_first(s_node);
     if (root_ep) {
@@ -242,6 +261,21 @@ void matter_bridge_update_operational_status(uint8_t status)
     esp_matter_attr_val_t val = esp_matter_uint8(status);
     attribute::update(s_endpoint_id, WindowCovering::Id,
                      WindowCovering::Attributes::OperationalStatus::Id, &val);
+}
+
+void matter_bridge_update_battery(uint8_t bat_charge_level, uint8_t bat_percent)
+{
+    ESP_LOGI(TAG, "Reporting battery: level=%u percent=%u", bat_charge_level, bat_percent);
+
+    esp_matter_attr_val_t level_val = esp_matter_uint8(bat_charge_level);
+    attribute::update(s_endpoint_id, PowerSource::Id,
+                     PowerSource::Attributes::BatChargeLevel::Id, &level_val);
+
+    // BatPercentRemaining is nullable, in half-percent units (0-200 = 0-100%).
+    uint8_t half_percent = (bat_percent > 100 ? 100 : bat_percent) * 2;
+    esp_matter_attr_val_t pct_val = esp_matter_nullable_uint8(nullable<uint8_t>(half_percent));
+    attribute::update(s_endpoint_id, PowerSource::Id,
+                     PowerSource::Attributes::BatPercentRemaining::Id, &pct_val);
 }
 
 bool matter_bridge_is_commissioned(void)

--- a/firmware/vent-controller/src/main.rs
+++ b/firmware/vent-controller/src/main.rs
@@ -142,6 +142,20 @@ fn main() {
     matter::start();
     matter::log_pairing_info();
 
+    let power_source = match power_mode {
+        PowerMode::AlwaysOn => PowerSource::Usb,
+        PowerMode::Sed { .. } => PowerSource::Battery,
+    };
+
+    // Report initial battery state via the Power Source cluster (#50) so
+    // HA's Matter integration has a battery sensor entity to show. This is
+    // a placeholder reading until #47 wires in the carrier board's real
+    // PackSense ADC sensing — without that hardware there's nothing real
+    // to report yet, but the Matter attribute path itself is exercised.
+    if power_source == PowerSource::Battery {
+        matter::update_battery(matter::BatteryChargeLevel::Ok, 100);
+    }
+
     // Build and publish the shared AppState. The main loop and Matter
     // handlers both reach into it via state::with_app_state.
     let app_state = AppState {
@@ -149,10 +163,7 @@ fn main() {
         identity: device_id,
         thread: thread_mgr,
         start_time: Instant::now(),
-        power_source: match power_mode {
-            PowerMode::AlwaysOn => PowerSource::Usb,
-            PowerMode::Sed { .. } => PowerSource::Battery,
-        },
+        power_source,
         poll_period_ms: power_mode.poll_period_ms(),
         identify_mode: false,
         identify_restore_angle: None,

--- a/firmware/vent-controller/src/matter.rs
+++ b/firmware/vent-controller/src/matter.rs
@@ -16,9 +16,27 @@ extern "C" {
     fn matter_bridge_start() -> i32;
     fn matter_bridge_update_position(percent100ths: u16);
     fn matter_bridge_update_operational_status(status: u8);
+    fn matter_bridge_update_battery(bat_charge_level: u8, bat_percent: u8);
     fn matter_bridge_is_commissioned() -> bool;
     fn matter_bridge_get_pairing_code(buf: *mut u8, len: usize) -> i32;
     fn matter_bridge_get_qr_payload(buf: *mut u8, len: usize) -> i32;
+}
+
+/// Matter's `BatChargeLevelEnum` (Power Source cluster, Battery feature).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatteryChargeLevel {
+    Ok = 0,
+    Warning = 1,
+    Critical = 2,
+}
+
+/// Report battery state via the Power Source cluster (issue #50), so HA's
+/// Matter integration surfaces a battery sensor entity. `percent` is
+/// 0-100; no-op call needed on USB-powered builds.
+pub fn update_battery(level: BatteryChargeLevel, percent: u8) {
+    unsafe {
+        matter_bridge_update_battery(level as u8, percent.min(100));
+    }
 }
 
 // --- Angle <-> Matter percent100ths conversion ---


### PR DESCRIPTION
## Summary

Closes the Matter-facing half of #50: adds a **Power Source cluster** (Battery feature) to the vent's existing Matter endpoint, alongside the Window Covering cluster, so Home Assistant's built-in Matter integration can surface a battery sensor entity per vent and drive low-battery automations — no custom HA component code needed.

- `components/esp_matter_bridge/matter_bridge.cpp` / `.h` — `cluster::power_source::create()` with the Battery feature added to the vent's endpoint at init, plus a new `matter_bridge_update_battery(level, percent)` C function that pushes `BatChargeLevel` + `BatPercentRemaining` attribute updates (the latter converted to the cluster's native half-percent units).
- `src/matter.rs` — `BatteryChargeLevel` enum mirroring Matter's `BatChargeLevelEnum` (Ok/Warning/Critical), and `update_battery()` wrapping the new FFI call.
- `src/main.rs` — reports an initial placeholder reading (`Ok`, 100%) for battery-powered builds at startup, to prove the Matter attribute path works end-to-end without depending on real hardware.

### What this PR is *not*

It doesn't add real battery sensing — that's the carrier board's `PackSense` ADC code, tracked separately in #47 (different branch/PR, not yet merged). Once that lands, the call site in `main.rs` should be replaced with a periodic real reading instead of the one-shot placeholder. This PR only builds and proves the Matter-facing plumbing.

It also doesn't extend to Google Home/Alexa — still explicitly out of scope per `docs/handbook.md`'s documented non-goal (a third-party OTBR can't join Google's first-party-only Matter fabric; HA is the only controller that can see this device at all).

## Test plan

- [x] Full clean rebuild (`cargo clean -p esp-idf-sys` + `cargo build --release`) — needed because incremental `cargo build` doesn't reliably pick up changes under the `extra_components` C++ tree, confirmed by checking `matter_bridge.cpp.obj`'s mtime before insisting on a clean rebuild
- [x] `matter_bridge.cpp` recompiled and linked successfully against the real esp-matter/CHIP SDK on `riscv32imac-esp-espidf`, producing a valid ELF binary
- [x] Verified the exact Power Source cluster API (cluster ID `0x2F`, `BatChargeLevelEnum`/`Feature::kBattery` values, `BatPercentRemaining`'s half-percent encoding) directly against the cached CHIP SDK headers this build actually uses, not from memory
- [ ] Not flashed to real hardware; not verified against an actual commissioned device that HA shows the expected battery sensor entity (needs a live vent + HA + matter-server to check)